### PR TITLE
Add MCP tool annotations (readOnlyHint, openWorldHint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added MCP tool annotations (`readOnlyHint`, `openWorldHint`) to all tools to help clients and users assess tool behavior ([#36355](https://github.com/giantswarm/giantswarm/issues/36355)).
+
 ## [0.1.0] - 2026-03-30
 
 ### Removed

--- a/internal/tools/prometheus/tools.go
+++ b/internal/tools/prometheus/tools.go
@@ -120,10 +120,21 @@ func withDynamicPrometheusClient(handler PrometheusHandler, client *Client, sc *
 	}
 }
 
-// Helper function to create and register a tool with common patterns
+// Helper function to create and register a tool with common patterns.
+//
+// All Prometheus tools in this server are read-only (they query Prometheus/Mimir
+// without mutating state) and target a bounded Prometheus/Mimir endpoint rather
+// than the open web, so readOnlyHint is always true and openWorldHint is always
+// false. destructiveHint and idempotentHint are omitted because they are only
+// meaningful when readOnlyHint is false.
 func registerPrometheusTools(s *mcpserver.MCPServer, client *Client, sc *server.ServerContext, middleware []ToolMiddleware, toolName string, description string, handler PrometheusHandler, options ...mcp.ToolOption) {
 	allOptions := withPrometheusConnectionParams(options...)
-	tool := mcp.NewTool(toolName, append([]mcp.ToolOption{mcp.WithDescription(description)}, allOptions...)...)
+	baseOptions := []mcp.ToolOption{
+		mcp.WithDescription(description),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+	}
+	tool := mcp.NewTool(toolName, append(baseOptions, allOptions...)...)
 
 	h := withDynamicPrometheusClient(handler, client, sc)
 	for _, mw := range middleware {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/36355

Follows the same approach used in https://github.com/giantswarm/mcp-kubernetes/pull/371 and https://github.com/giantswarm/search-mcp/pull/114.

## Summary

Annotates all MCP tools with [MCP tool annotation hints](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations) so clients (e.g. MCP Inspector) and users can assess tool behavior at a glance.

Every tool in this server is a read-only query against a bounded Prometheus/Mimir endpoint, so:

- `readOnlyHint` is `true` for all tools
- `openWorldHint` is `false` for all tools (the target is a configured Prometheus/Mimir server, not the open web)
- `destructiveHint` and `idempotentHint` are omitted — per the MCP spec they are only meaningful when `readOnlyHint` is `false`

Because the annotations are identical for every tool, they are applied centrally in the `registerPrometheusTools` helper rather than repeated on each call. New tools added via this helper inherit the correct annotations by construction.

Tools covered (all with `readOnlyHint: true`, `openWorldHint: false`):

| Tool |
| --- |
| `execute_query` |
| `execute_range_query` |
| `get_metric_metadata` |
| `list_label_names` |
| `list_label_values` |
| `find_series` |
| `get_targets` |
| `get_build_info` |
| `get_runtime_info` |
| `get_flags` |
| `get_config` |
| `get_alerts` |
| `get_alertmanagers` |
| `get_rules` |
| `get_tsdb_stats` |
| `query_exemplars` |
| `get_targets_metadata` |
| `check_ready` |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Verify annotations appear in MCP Inspector

🤖 Generated with [Claude Code](https://claude.com/claude-code)