### PR TITLE
ci: fix pre-commit auto-formatter violations

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -4,4 +4,4 @@ generate-metadata: true
 chart-dir: ./helm/mcp-prometheus
 destination: ./build
 # CI overwrites this, check .circleci/config.yaml
-catalog-base-url: https://giantswarm.github.io/giantswarm-catalog/ 
+catalog-base-url: https://giantswarm.github.io/giantswarm-catalog/

--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
 # Architecture Principles

--- a/.cursor/rules/cursor_rules.mdc
+++ b/.cursor/rules/cursor_rules.mdc
@@ -27,7 +27,7 @@ alwaysApply: true
   ```typescript
   // ✅ DO: Show good examples
   const goodExample = true;
-  
+
   // ❌ DON'T: Show anti-patterns
   const badExample = false;
   ```
@@ -50,4 +50,4 @@ alwaysApply: true
   - Keep descriptions concise
   - Include both DO and DON'T examples
   - Reference actual code over theoretical examples
-  - Use consistent formatting across rules 
+  - Use consistent formatting across rules

--- a/.cursor/rules/mcp-debugging.mdc
+++ b/.cursor/rules/mcp-debugging.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
 ## Debugging mcp-prometheus via mcp-debug

--- a/.cursor/rules/self_improve.mdc
+++ b/.cursor/rules/self_improve.mdc
@@ -38,7 +38,7 @@ alwaysApply: true
     select: { id: true, email: true },
     where: { status: 'ACTIVE' }
   });
-  
+
   // Consider adding to [prisma.mdc](mdc:.cursor/rules/prisma.mdc):
   // - Standard select fields
   // - Common where conditions

--- a/helm/mcp-prometheus/.helmignore
+++ b/helm/mcp-prometheus/.helmignore
@@ -20,4 +20,4 @@
 .project
 .idea/
 *.tmproj
-.vscode/ 
+.vscode/

--- a/helm/mcp-prometheus/templates/NOTES.txt
+++ b/helm/mcp-prometheus/templates/NOTES.txt
@@ -65,7 +65,7 @@
    {{- if ne .Values.app.server.transport "stdio" }}
    # Port-forward to test the server
    kubectl port-forward svc/{{ include "mcp-prometheus.fullname" . }} 8080:{{ .Values.service.port }} -n {{ .Release.Namespace }}
-   
+
    # Test the MCP tools list endpoint
    curl -X POST http://localhost:8080{{ .Values.app.server.httpEndpoint }} \
      -H "Content-Type: application/json" \
@@ -88,7 +88,7 @@
    The deployment includes intelligent MCP-specific health probes:
    - Liveness Probe: Tests MCP JSON-RPC functionality every {{ .Values.livenessProbe.periodSeconds | default 30 }}s
    - Readiness Probe: Verifies MCP tools/list endpoint every {{ .Values.readinessProbe.periodSeconds | default 10 }}s
-   
+
    Monitor application health using:
    - Pod status: kubectl get pods -n {{ .Release.Namespace }}
    - Health probe status: kubectl describe pod -n {{ .Release.Namespace }} -l "{{ include "mcp-prometheus.selectorLabels" . }}"
@@ -104,4 +104,4 @@
 7. For more information, visit:
    - Project: https://github.com/giantswarm/mcp-prometheus
    - Documentation: https://github.com/giantswarm/mcp-prometheus/blob/main/README.md
-   - Helm Chart README: https://github.com/giantswarm/mcp-prometheus/blob/main/helm/mcp-prometheus/README.md 
+   - Helm Chart README: https://github.com/giantswarm/mcp-prometheus/blob/main/helm/mcp-prometheus/README.md

--- a/helm/mcp-prometheus/templates/_helpers.tpl
+++ b/helm/mcp-prometheus/templates/_helpers.tpl
@@ -67,4 +67,4 @@ Create the image path
 */}}
 {{- define "mcp-prometheus.image" -}}
 {{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
-{{- end }} 
+{{- end }}

--- a/helm/mcp-prometheus/templates/deployment.yaml
+++ b/helm/mcp-prometheus/templates/deployment.yaml
@@ -173,4 +173,4 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-      {{- end }} 
+      {{- end }}

--- a/helm/mcp-prometheus/templates/hpa.yaml
+++ b/helm/mcp-prometheus/templates/hpa.yaml
@@ -32,4 +32,4 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
-{{- end }} 
+{{- end }}

--- a/helm/mcp-prometheus/templates/ingress.yaml
+++ b/helm/mcp-prometheus/templates/ingress.yaml
@@ -56,4 +56,4 @@ spec:
               {{- end }}
           {{- end }}
     {{- end }}
-{{- end }} 
+{{- end }}

--- a/helm/mcp-prometheus/templates/serviceaccount.yaml
+++ b/helm/mcp-prometheus/templates/serviceaccount.yaml
@@ -10,4 +10,4 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
-{{- end }} 
+{{- end }}


### PR DESCRIPTION
## Summary
- Apply the trailing-whitespace and end-of-file-fixer auto-fixes flagged by the shared `giantswarm/github` pre-commit workflow
- Scope is limited to whitespace/EOL changes in `.abs/`, `.cursor/rules/`, and `helm/mcp-prometheus/` sources — no code, schema, or `zz_*` files touched

## Context
The `pre-commit` CI has been failing on `main` on pre-existing formatter violations, blocking Renovate/Align-files PRs from merging. This PR absorbs those auto-fixer violations so downstream PRs can progress cleanly.

## Test plan
- [x] `pre-commit` CI picks up the cleaned files and reports no whitespace/EOF hook failures on subsequent runs