### PR TITLE
ci: finish pre-commit cleanup (errcheck fixes)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -278,7 +278,10 @@ func serveHTTPWithShutdown(ctx context.Context, addr string, handler http.Handle
 		return fmt.Errorf("listen %s: %w", addr, err)
 	}
 
-	srv := &http.Server{Handler: handler}
+	srv := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -328,13 +331,10 @@ func runStdioServer(mcpSrv *mcpserver.MCPServer, logger *slog.Logger) error {
 	}()
 
 	// Wait for server completion
-	select {
-	case err := <-serverDone:
-		if err != nil {
-			return fmt.Errorf("server stopped with error: %w", err)
-		}
-		logger.Info("Server stopped normally")
+	if err := <-serverDone; err != nil {
+		return fmt.Errorf("server stopped with error: %w", err)
 	}
+	logger.Info("Server stopped normally")
 
 	logger.Info("Server gracefully stopped")
 	return nil

--- a/internal/oauth/setup.go
+++ b/internal/oauth/setup.go
@@ -82,22 +82,25 @@ type Config struct {
 	AllowPrivateURLs bool
 }
 
+// envTrue is the string value that enables a boolean env var.
+const envTrue = "true"
+
 // ConfigFromEnv builds a Config by reading the standard environment variables.
 func ConfigFromEnv() Config {
 	cfg := Config{
 		Issuer:                  os.Getenv("MCP_OAUTH_ISSUER"),
 		EncryptionKey:           os.Getenv("MCP_OAUTH_ENCRYPTION_KEY"),
-		AllowPublicRegistration: os.Getenv("MCP_OAUTH_ALLOW_PUBLIC_REGISTRATION") == "true",
+		AllowPublicRegistration: os.Getenv("MCP_OAUTH_ALLOW_PUBLIC_REGISTRATION") == envTrue,
 		StorageType:             os.Getenv("OAUTH_STORAGE"),
 		ValkeyURL:               os.Getenv("VALKEY_URL"),
 		ValkeyPassword:          os.Getenv("VALKEY_PASSWORD"),
-		ValkeyTLS:               os.Getenv("VALKEY_TLS_ENABLED") == "true",
+		ValkeyTLS:               os.Getenv("VALKEY_TLS_ENABLED") == envTrue,
 		ValkeyKeyPrefix:         os.Getenv("VALKEY_KEY_PREFIX"),
 		DexIssuerURL:            os.Getenv("DEX_ISSUER_URL"),
 		DexClientID:             os.Getenv("DEX_CLIENT_ID"),
 		DexClientSecret:         os.Getenv("DEX_CLIENT_SECRET"),
 		DexRedirectURL:          os.Getenv("DEX_REDIRECT_URL"),
-		AllowPrivateURLs:        os.Getenv("MCP_OAUTH_ALLOW_PRIVATE_URLS") == "true",
+		AllowPrivateURLs:        os.Getenv("MCP_OAUTH_ALLOW_PRIVATE_URLS") == envTrue,
 	}
 	if v := os.Getenv("OAUTH_TRUSTED_AUDIENCES"); v != "" {
 		for _, a := range strings.Split(v, ",") {

--- a/internal/oauth/setup_test.go
+++ b/internal/oauth/setup_test.go
@@ -3,14 +3,15 @@ package oauth
 import (
 	"context"
 	"log/slog"
-	"os"
 	"testing"
 
 	"github.com/giantswarm/mcp-oauth/providers/mock"
 )
 
 func TestConfigFromEnvDefaults(t *testing.T) {
-	// Unset any OAuth env vars to test defaults.
+	// Clear any OAuth env vars to test defaults. ConfigFromEnv uses os.Getenv,
+	// which returns "" whether the var is unset or empty, so t.Setenv(key, "")
+	// is equivalent and auto-restores at test end.
 	for _, key := range []string{
 		"MCP_OAUTH_ISSUER", "MCP_OAUTH_ENCRYPTION_KEY",
 		"MCP_OAUTH_ALLOW_PUBLIC_REGISTRATION",
@@ -19,7 +20,7 @@ func TestConfigFromEnvDefaults(t *testing.T) {
 		"VALKEY_TLS_ENABLED", "VALKEY_KEY_PREFIX",
 		"DEX_ISSUER_URL", "DEX_CLIENT_ID", "DEX_CLIENT_SECRET", "DEX_REDIRECT_URL",
 	} {
-		os.Unsetenv(key)
+		t.Setenv(key, "")
 	}
 
 	cfg := ConfigFromEnv()
@@ -39,29 +40,18 @@ func TestConfigFromEnvDefaults(t *testing.T) {
 }
 
 func TestConfigFromEnvReadsValues(t *testing.T) {
-	os.Setenv("MCP_OAUTH_ISSUER", "https://issuer.example.com")
-	os.Setenv("MCP_OAUTH_ENCRYPTION_KEY", "deadbeef")
-	os.Setenv("MCP_OAUTH_ALLOW_PUBLIC_REGISTRATION", "true")
-	os.Setenv("OAUTH_STORAGE", "valkey")
-	os.Setenv("VALKEY_URL", "valkey://localhost:6379")
-	os.Setenv("VALKEY_PASSWORD", "secret")
-	os.Setenv("VALKEY_TLS_ENABLED", "true")
-	os.Setenv("VALKEY_KEY_PREFIX", "myapp:")
-	os.Setenv("DEX_ISSUER_URL", "https://dex.example.com")
-	os.Setenv("DEX_CLIENT_ID", "mcp-prometheus")
-	os.Setenv("DEX_CLIENT_SECRET", "dexsecret")
-	os.Setenv("DEX_REDIRECT_URL", "https://app.example.com/oauth/callback")
-	defer func() {
-		for _, key := range []string{
-			"MCP_OAUTH_ISSUER", "MCP_OAUTH_ENCRYPTION_KEY",
-			"MCP_OAUTH_ALLOW_PUBLIC_REGISTRATION",
-			"OAUTH_STORAGE", "VALKEY_URL", "VALKEY_PASSWORD",
-			"VALKEY_TLS_ENABLED", "VALKEY_KEY_PREFIX",
-			"DEX_ISSUER_URL", "DEX_CLIENT_ID", "DEX_CLIENT_SECRET", "DEX_REDIRECT_URL",
-		} {
-			os.Unsetenv(key)
-		}
-	}()
+	t.Setenv("MCP_OAUTH_ISSUER", "https://issuer.example.com")
+	t.Setenv("MCP_OAUTH_ENCRYPTION_KEY", "deadbeef")
+	t.Setenv("MCP_OAUTH_ALLOW_PUBLIC_REGISTRATION", "true")
+	t.Setenv("OAUTH_STORAGE", "valkey")
+	t.Setenv("VALKEY_URL", "valkey://localhost:6379")
+	t.Setenv("VALKEY_PASSWORD", "secret")
+	t.Setenv("VALKEY_TLS_ENABLED", "true")
+	t.Setenv("VALKEY_KEY_PREFIX", "myapp:")
+	t.Setenv("DEX_ISSUER_URL", "https://dex.example.com")
+	t.Setenv("DEX_CLIENT_ID", "mcp-prometheus")
+	t.Setenv("DEX_CLIENT_SECRET", "dexsecret")
+	t.Setenv("DEX_REDIRECT_URL", "https://app.example.com/oauth/callback")
 
 	cfg := ConfigFromEnv()
 
@@ -95,8 +85,7 @@ func TestConfigFromEnvReadsValues(t *testing.T) {
 }
 
 func TestConfigFromEnvAllowPrivateURLs(t *testing.T) {
-	os.Setenv("MCP_OAUTH_ALLOW_PRIVATE_URLS", "true")
-	defer os.Unsetenv("MCP_OAUTH_ALLOW_PRIVATE_URLS")
+	t.Setenv("MCP_OAUTH_ALLOW_PRIVATE_URLS", "true")
 
 	cfg := ConfigFromEnv()
 	if !cfg.AllowPrivateURLs {

--- a/internal/observability/health.go
+++ b/internal/observability/health.go
@@ -21,7 +21,7 @@ func (h *Health) HealthzHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok")) //nolint:errcheck
+		_, _ = w.Write([]byte("ok"))
 	}
 }
 
@@ -33,10 +33,10 @@ func (h *Health) ReadyzHandler() http.HandlerFunc {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		if h.ready.Load() {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("ready")) //nolint:errcheck
+			_, _ = w.Write([]byte("ready"))
 		} else {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			w.Write([]byte("not ready")) //nolint:errcheck
+			_, _ = w.Write([]byte("not ready"))
 		}
 	}
 }

--- a/internal/observability/instrument.go
+++ b/internal/observability/instrument.go
@@ -10,6 +10,9 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// statusError is the metric label value used when a tool call fails.
+const statusError = "error"
+
 // Instrumentor wraps MCP tool handlers to record Prometheus metrics and
 // OpenTelemetry spans for every tool invocation.
 type Instrumentor struct {
@@ -47,16 +50,16 @@ func (i *Instrumentor) Wrap(
 		status := "success"
 		switch {
 		case err != nil:
-			status = "error"
+			status = statusError
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 		case result == nil:
 			// Handlers must return a non-nil result when err is nil; treat this
 			// as an internal error so it shows up in metrics and traces.
-			status = "error"
+			status = statusError
 			span.SetStatus(codes.Error, "handler returned nil result with no error")
 		case result.IsError:
-			status = "error"
+			status = statusError
 			span.SetStatus(codes.Error, "tool returned an error result")
 		}
 

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -197,9 +197,9 @@ func TestInstrumentorWrapNilResult(t *testing.T) {
 func TestInstrumentorWrapRecordsLatency(t *testing.T) {
 	inst := noopInstrumentor()
 
-	inst.Wrap("latency_tool", func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_, _ = inst.Wrap("latency_tool", func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return &mcp.CallToolResult{}, nil
-	})(context.Background(), mcp.CallToolRequest{}) //nolint:errcheck
+	})(context.Background(), mcp.CallToolRequest{})
 
 	if !strings.Contains(metricsBody(t, inst.metrics), "mcp_prometheus_tool_call_duration_seconds") {
 		t.Error("expected duration histogram in metrics output")
@@ -298,7 +298,7 @@ func TestServeExitsWhenListenerClosed(t *testing.T) {
 		t.Fatalf("could not create listener: %v", err)
 	}
 	// Close the listener immediately; Serve should detect this and return via errCh.
-	ln.Close()
+	_ = ln.Close()
 
 	ctx := context.Background()
 	done := make(chan error, 1)
@@ -340,8 +340,8 @@ func TestRunServerShutdownOnContextCancel(t *testing.T) {
 		cancel()
 		t.Fatalf("GET /healthz failed: %v", err)
 	}
-	io.Copy(io.Discard, resp.Body) //nolint:errcheck
-	resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
 
 	cancel()
 
@@ -363,7 +363,7 @@ func freeTCPAddr() (string, error) {
 		return "", err
 	}
 	addr := ln.Addr().String()
-	ln.Close()
+	_ = ln.Close()
 	return addr, nil
 }
 
@@ -373,8 +373,8 @@ func waitForHTTP(addr string, timeout time.Duration) error {
 	for time.Now().Before(deadline) {
 		resp, err := http.Get(fmt.Sprintf("http://%s/healthz", addr))
 		if err == nil {
-			io.Copy(io.Discard, resp.Body) //nolint:errcheck
-			resp.Body.Close()
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
 			return nil
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/internal/tenancy/static_test.go
+++ b/internal/tenancy/static_test.go
@@ -5,90 +5,95 @@ import (
 	"testing"
 )
 
+const (
+	tenantProdEU    = "prod-eu"
+	overwrittenMark = "OVERWRITTEN"
+)
+
 func TestStaticResolver_AllUsersMode_ReturnsFixedList(t *testing.T) {
-	r := NewStaticResolver([]string{"prod-eu", "staging"}, nil)
+	r := NewStaticResolver([]string{tenantProdEU, "staging"}, nil)
 	tenants, err := r.TenantsForGroups(context.Background(), []string{"any-group"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(tenants) != 2 || tenants[0] != "prod-eu" || tenants[1] != "staging" {
+	if len(tenants) != 2 || tenants[0] != tenantProdEU || tenants[1] != "staging" {
 		t.Errorf("got %v, want [prod-eu staging]", tenants)
 	}
 }
 
 func TestStaticResolver_AllUsersMode_NilGroups(t *testing.T) {
-	r := NewStaticResolver([]string{"prod-eu"}, nil)
+	r := NewStaticResolver([]string{tenantProdEU}, nil)
 	tenants, err := r.TenantsForGroups(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(tenants) != 1 || tenants[0] != "prod-eu" {
+	if len(tenants) != 1 || tenants[0] != tenantProdEU {
 		t.Errorf("got %v, want [prod-eu]", tenants)
 	}
 }
 
 func TestStaticResolver_AllUsersMode_EmptyGroupMap(t *testing.T) {
-	r := NewStaticResolver([]string{"prod-eu"}, map[string][]string{})
+	r := NewStaticResolver([]string{tenantProdEU}, map[string][]string{})
 	tenants, err := r.TenantsForGroups(context.Background(), []string{"team-ops"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(tenants) != 1 || tenants[0] != "prod-eu" {
+	if len(tenants) != 1 || tenants[0] != tenantProdEU {
 		t.Errorf("got %v, want [prod-eu]", tenants)
 	}
 }
 
 func TestStaticResolver_AllUsersMode_MutationIsolation(t *testing.T) {
-	input := []string{"prod-eu", "staging"}
+	input := []string{tenantProdEU, "staging"}
 	r := NewStaticResolver(input, nil)
 
 	// Mutate the input slice after construction.
-	input[0] = "OVERWRITTEN"
+	input[0] = overwrittenMark
 
 	tenants, _ := r.TenantsForGroups(context.Background(), nil)
-	if tenants[0] != "prod-eu" {
+	if tenants[0] != tenantProdEU {
 		t.Errorf("resolver was affected by external mutation: got %v", tenants)
 	}
 }
 
 func TestStaticResolver_AllUsersMode_ReturnCopyIsolation(t *testing.T) {
-	r := NewStaticResolver([]string{"prod-eu"}, nil)
+	r := NewStaticResolver([]string{tenantProdEU}, nil)
 	tenants, _ := r.TenantsForGroups(context.Background(), nil)
 
 	// Mutate the returned slice.
-	tenants[0] = "OVERWRITTEN"
+	tenants[0] = overwrittenMark
 
 	tenants2, _ := r.TenantsForGroups(context.Background(), nil)
-	if tenants2[0] != "prod-eu" {
+	if tenants2[0] != tenantProdEU {
 		t.Errorf("resolver state was mutated via returned slice: got %v", tenants2)
 	}
 }
 
 func TestStaticResolver_GroupMapping_SingleMatch(t *testing.T) {
 	r := NewStaticResolver(nil, map[string][]string{
-		"team-ops": {"prod-eu", "prod-us"},
+		"team-ops": {tenantProdEU, "prod-us"},
 		"team-dev": {"staging"},
 	})
 	tenants, err := r.TenantsForGroups(context.Background(), []string{"team-ops"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(tenants) != 2 || tenants[0] != "prod-eu" || tenants[1] != "prod-us" {
+	if len(tenants) != 2 || tenants[0] != tenantProdEU || tenants[1] != "prod-us" {
 		t.Errorf("got %v, want [prod-eu prod-us]", tenants)
 	}
 }
 
 func TestStaticResolver_GroupMapping_MultipleGroups_UnionAndDedup(t *testing.T) {
 	r := NewStaticResolver(nil, map[string][]string{
-		"team-ops": {"prod-eu", "prod-us"},
-		"team-dev": {"prod-eu", "staging"}, // prod-eu shared
+		"team-ops": {tenantProdEU, "prod-us"},
+		"team-dev": {tenantProdEU, "staging"}, // prod-eu shared
 	})
 	tenants, err := r.TenantsForGroups(context.Background(), []string{"team-ops", "team-dev"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// Expect sorted, deduplicated union.
-	want := []string{"prod-eu", "prod-us", "staging"}
+	want := []string{tenantProdEU, "prod-us", "staging"}
 	if len(tenants) != len(want) {
 		t.Fatalf("got %v, want %v", tenants, want)
 	}
@@ -101,7 +106,7 @@ func TestStaticResolver_GroupMapping_MultipleGroups_UnionAndDedup(t *testing.T) 
 
 func TestStaticResolver_GroupMapping_NoMatch(t *testing.T) {
 	r := NewStaticResolver(nil, map[string][]string{
-		"team-ops": {"prod-eu"},
+		"team-ops": {tenantProdEU},
 	})
 	tenants, err := r.TenantsForGroups(context.Background(), []string{"team-unknown"})
 	if err != nil {
@@ -114,7 +119,7 @@ func TestStaticResolver_GroupMapping_NoMatch(t *testing.T) {
 
 func TestStaticResolver_GroupMapping_NilGroups(t *testing.T) {
 	r := NewStaticResolver(nil, map[string][]string{
-		"team-ops": {"prod-eu"},
+		"team-ops": {tenantProdEU},
 	})
 	tenants, err := r.TenantsForGroups(context.Background(), nil)
 	if err != nil {
@@ -128,29 +133,29 @@ func TestStaticResolver_GroupMapping_NilGroups(t *testing.T) {
 func TestStaticResolver_GroupMapping_TakesPrecedenceOverAllTenants(t *testing.T) {
 	// When groupMap is non-empty, allTenants must be ignored.
 	r := NewStaticResolver([]string{"should-be-ignored"}, map[string][]string{
-		"team-ops": {"prod-eu"},
+		"team-ops": {tenantProdEU},
 	})
 	tenants, err := r.TenantsForGroups(context.Background(), []string{"team-ops"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(tenants) != 1 || tenants[0] != "prod-eu" {
+	if len(tenants) != 1 || tenants[0] != tenantProdEU {
 		t.Errorf("got %v, want [prod-eu]", tenants)
 	}
 }
 
 func TestStaticResolver_GroupMapping_MutationIsolation(t *testing.T) {
 	groupMap := map[string][]string{
-		"team-ops": {"prod-eu"},
+		"team-ops": {tenantProdEU},
 	}
 	r := NewStaticResolver(nil, groupMap)
 
 	// Mutate the map and its values after construction.
-	groupMap["team-ops"][0] = "OVERWRITTEN"
+	groupMap["team-ops"][0] = overwrittenMark
 	groupMap["team-new"] = []string{"staging"}
 
 	tenants, _ := r.TenantsForGroups(context.Background(), []string{"team-ops"})
-	if len(tenants) != 1 || tenants[0] != "prod-eu" {
+	if len(tenants) != 1 || tenants[0] != tenantProdEU {
 		t.Errorf("resolver was affected by external mutation: got %v", tenants)
 	}
 	tenants2, _ := r.TenantsForGroups(context.Background(), []string{"team-new"})

--- a/internal/tools/prometheus/client.go
+++ b/internal/tools/prometheus/client.go
@@ -77,7 +77,7 @@ func NewClient(config server.PrometheusConfig, logger *slog.Logger) (*Client, er
 	}
 
 	// Start with default transport, or a custom TLS transport when needed
-	var roundTripper http.RoundTripper = http.DefaultTransport
+	var roundTripper = http.DefaultTransport
 
 	if config.TLSSkipVerify || config.TLSCACert != "" {
 		tlsConfig := &tls.Config{
@@ -147,7 +147,7 @@ type QueryResult struct {
 // ExecuteQuery executes an instant PromQL query
 func (c *Client) ExecuteQuery(ctx context.Context, query string, timeParam string) (*QueryResult, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	var queryTime time.Time
@@ -188,7 +188,7 @@ func (c *Client) ExecuteQuery(ctx context.Context, query string, timeParam strin
 // ExecuteQueryWithOptions executes an instant PromQL query with additional options
 func (c *Client) ExecuteQueryWithOptions(ctx context.Context, query string, timeParam string, options QueryOptions) (*QueryResult, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	var queryTime time.Time
@@ -256,7 +256,7 @@ func (c *Client) ExecuteQueryWithOptions(ctx context.Context, query string, time
 // ExecuteRangeQuery executes a range PromQL query
 func (c *Client) ExecuteRangeQuery(ctx context.Context, query, start, end, step string) (*QueryResult, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	// Parse start time
@@ -304,7 +304,7 @@ func (c *Client) ExecuteRangeQuery(ctx context.Context, query, start, end, step 
 // ExecuteRangeQueryWithOptions executes a range PromQL query with additional options
 func (c *Client) ExecuteRangeQueryWithOptions(ctx context.Context, query, start, end, step string, options QueryOptions) (*QueryResult, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	// Parse start time
@@ -400,7 +400,7 @@ type MetricMetadataOptions struct {
 // GetMetricMetadataWithOptions gets metadata for a specific metric with options
 func (c *Client) GetMetricMetadataWithOptions(ctx context.Context, metric string, options MetricMetadataOptions) (MetricMetadata, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -441,7 +441,7 @@ type TargetsResult struct {
 // GetTargets gets information about scrape targets
 func (c *Client) GetTargets(ctx context.Context) (*TargetsResult, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -492,7 +492,7 @@ type LabelNamesResult struct {
 // ListLabelNames gets all available label names
 func (c *Client) ListLabelNames(ctx context.Context, options LabelOptions) (*LabelNamesResult, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -557,7 +557,7 @@ type LabelOptions struct {
 // ListLabelValues gets values for a specific label
 func (c *Client) ListLabelValues(ctx context.Context, label string, options LabelOptions) (*LabelValuesResult, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -627,7 +627,7 @@ type SeriesOptions struct {
 // FindSeries finds series by label matchers
 func (c *Client) FindSeries(ctx context.Context, matches []string, options SeriesOptions) (*SeriesResult, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -687,7 +687,7 @@ func (c *Client) FindSeries(ctx context.Context, matches []string, options Serie
 // GetRules gets recording and alerting rules
 func (c *Client) GetRules(ctx context.Context) (interface{}, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -704,7 +704,7 @@ func (c *Client) GetRules(ctx context.Context) (interface{}, error) {
 // GetAlerts gets active alerts
 func (c *Client) GetAlerts(ctx context.Context) (interface{}, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -721,7 +721,7 @@ func (c *Client) GetAlerts(ctx context.Context) (interface{}, error) {
 // GetAlertManagers gets AlertManager discovery info
 func (c *Client) GetAlertManagers(ctx context.Context) (interface{}, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -738,7 +738,7 @@ func (c *Client) GetAlertManagers(ctx context.Context) (interface{}, error) {
 // GetConfig gets Prometheus configuration
 func (c *Client) GetConfig(ctx context.Context) (interface{}, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -755,7 +755,7 @@ func (c *Client) GetConfig(ctx context.Context) (interface{}, error) {
 // GetFlags gets runtime flags
 func (c *Client) GetFlags(ctx context.Context) (interface{}, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -772,7 +772,7 @@ func (c *Client) GetFlags(ctx context.Context) (interface{}, error) {
 // GetBuildInfo gets build information
 func (c *Client) GetBuildInfo(ctx context.Context) (interface{}, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -789,7 +789,7 @@ func (c *Client) GetBuildInfo(ctx context.Context) (interface{}, error) {
 // GetRuntimeInfo gets runtime information
 func (c *Client) GetRuntimeInfo(ctx context.Context) (interface{}, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -806,7 +806,7 @@ func (c *Client) GetRuntimeInfo(ctx context.Context) (interface{}, error) {
 // GetTSDBStats gets TSDB cardinality statistics
 func (c *Client) GetTSDBStats(ctx context.Context, options TSDBOptions) (interface{}, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -836,7 +836,7 @@ type TSDBOptions struct {
 // QueryExemplars queries exemplars for traces
 func (c *Client) QueryExemplars(ctx context.Context, query, start, end string) (interface{}, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -882,7 +882,7 @@ type HealthStatus struct {
 // route for.
 func (c *Client) CheckReady(ctx context.Context) (*HealthStatus, error) {
 	if c.httpClient == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	parsed, err := url.Parse(c.config.URL)
@@ -914,7 +914,7 @@ func (c *Client) doReadyCheck(ctx context.Context, readyURL string) (*HealthStat
 	if err != nil {
 		return nil, fmt.Errorf("readiness check request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
 	if err != nil {
 		c.logger.Warn("Failed to read readiness response body", "error", err)
@@ -929,7 +929,7 @@ func (c *Client) doReadyCheck(ctx context.Context, readyURL string) (*HealthStat
 // GetTargetsMetadata gets metadata about metrics from specific targets
 func (c *Client) GetTargetsMetadata(ctx context.Context, matchTarget, metric, limit string) (interface{}, error) {
 	if c.client == nil {
-		return nil, fmt.Errorf("Prometheus client not initialized")
+		return nil, fmt.Errorf("prometheus client not initialized")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)

--- a/internal/tools/prometheus/client_test.go
+++ b/internal/tools/prometheus/client_test.go
@@ -21,7 +21,7 @@ func tlsQueryHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == "/api/v1/query" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(queryResponse)) //nolint:errcheck
+		_, _ = w.Write([]byte(queryResponse))
 	} else {
 		w.WriteHeader(http.StatusNotFound)
 	}
@@ -81,7 +81,7 @@ func TestNewClientCustomCA(t *testing.T) {
 	if _, err := tmpFile.Write(certPEM); err != nil {
 		t.Fatalf("failed to write CA cert: %v", err)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	config := server.PrometheusConfig{
 		URL:       mockServer.URL,
@@ -117,8 +117,8 @@ func TestNewClientTLSInvalidPEM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
-	tmpFile.WriteString("this is definitely not valid PEM content") //nolint:errcheck
-	tmpFile.Close()
+	_, _ = tmpFile.WriteString("this is definitely not valid PEM content")
+	_ = tmpFile.Close()
 
 	config := server.PrometheusConfig{
 		URL:       "https://localhost:9090",
@@ -153,7 +153,7 @@ func TestNewClientTLSSkipVerifyWithCustomCA(t *testing.T) {
 	if _, err := tmpFile.Write(certPEM); err != nil {
 		t.Fatalf("failed to write CA cert: %v", err)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	config := server.PrometheusConfig{
 		URL:           mockServer.URL,

--- a/internal/tools/prometheus/tools_test.go
+++ b/internal/tools/prometheus/tools_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/giantswarm/mcp-prometheus/internal/server"
 )
 
+const apiQueryPath = "/api/v1/query"
+
 // discardLogger returns a *slog.Logger that discards all output.
 func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -33,7 +35,7 @@ func TestRegisterPrometheusTools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create server context: %v", err)
 	}
-	defer sc.Shutdown()
+	defer func() { _ = sc.Shutdown() }()
 
 	if err := RegisterPrometheusTools(s, sc); err != nil {
 		t.Fatalf("Failed to register tools: %v", err)
@@ -42,8 +44,8 @@ func TestRegisterPrometheusTools(t *testing.T) {
 
 func TestRegisterPrometheusToolsWithMiddleware(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/query" {
-			json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
+		if r.URL.Path == apiQueryPath {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"status": "success",
 				"data":   map[string]interface{}{"resultType": "vector", "result": []interface{}{}},
 			})
@@ -61,7 +63,7 @@ func TestRegisterPrometheusToolsWithMiddleware(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create server context: %v", err)
 	}
-	defer sc.Shutdown()
+	defer func() { _ = sc.Shutdown() }()
 
 	// Middleware that records the tool name for every invocation through the
 	// server's dispatch path.
@@ -172,7 +174,7 @@ func TestClient(t *testing.T) {
 				if r.URL.Path == tt.endpoint {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
-					w.Write([]byte(tt.response))
+					_, _ = w.Write([]byte(tt.response))
 				} else {
 					w.WriteHeader(http.StatusNotFound)
 				}
@@ -197,7 +199,7 @@ func TestClient(t *testing.T) {
 func TestHandleExecuteQuery(t *testing.T) {
 	// Create mock server
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/query" {
+		if r.URL.Path == apiQueryPath {
 			response := map[string]interface{}{
 				"status": "success",
 				"data": map[string]interface{}{
@@ -205,7 +207,7 @@ func TestHandleExecuteQuery(t *testing.T) {
 					"result":     []interface{}{},
 				},
 			}
-			json.NewEncoder(w).Encode(response)
+			_ = json.NewEncoder(w).Encode(response)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -223,7 +225,7 @@ func TestHandleExecuteQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create server context: %v", err)
 	}
-	defer sc.Shutdown()
+	defer func() { _ = sc.Shutdown() }()
 
 	client, err := NewClient(sc.PrometheusConfig(), sc.Logger())
 	if err != nil {
@@ -278,7 +280,7 @@ func TestHandleExecuteRangeQuery(t *testing.T) {
 					"result":     []interface{}{},
 				},
 			}
-			json.NewEncoder(w).Encode(response)
+			_ = json.NewEncoder(w).Encode(response)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -296,7 +298,7 @@ func TestHandleExecuteRangeQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create server context: %v", err)
 	}
-	defer sc.Shutdown()
+	defer func() { _ = sc.Shutdown() }()
 
 	client, err := NewClient(sc.PrometheusConfig(), sc.Logger())
 	if err != nil {
@@ -342,7 +344,7 @@ func TestHandleGetMetricMetadata(t *testing.T) {
 					},
 				},
 			}
-			json.NewEncoder(w).Encode(response)
+			_ = json.NewEncoder(w).Encode(response)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -360,7 +362,7 @@ func TestHandleGetMetricMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create server context: %v", err)
 	}
-	defer sc.Shutdown()
+	defer func() { _ = sc.Shutdown() }()
 
 	client, err := NewClient(sc.PrometheusConfig(), sc.Logger())
 	if err != nil {
@@ -403,7 +405,7 @@ func TestCheckReady(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tt.statusCode)
-				w.Write([]byte(tt.body)) //nolint:errcheck
+				_, _ = w.Write([]byte(tt.body))
 			}))
 			defer srv.Close()
 
@@ -446,10 +448,10 @@ func TestCheckReadyMimirFallback(t *testing.T) {
 		switch r.URL.Path {
 		case "/-/ready":
 			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte("not found")) //nolint:errcheck
+			_, _ = w.Write([]byte("not found"))
 		case "/ready":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("ready")) //nolint:errcheck
+			_, _ = w.Write([]byte("ready"))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -497,7 +499,7 @@ func TestHandleCheckReady(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tt.statusCode)
-				w.Write([]byte(tt.body)) //nolint:errcheck
+				_, _ = w.Write([]byte(tt.body))
 			}))
 			defer srv.Close()
 
@@ -509,7 +511,7 @@ func TestHandleCheckReady(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create server context: %v", err)
 			}
-			defer sc.Shutdown()
+			defer func() { _ = sc.Shutdown() }()
 
 			client, err := NewClient(sc.PrometheusConfig(), sc.Logger())
 			if err != nil {
@@ -539,7 +541,7 @@ func TestHandleCheckReadyConnectionError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create server context: %v", err)
 	}
-	defer sc.Shutdown()
+	defer func() { _ = sc.Shutdown() }()
 
 	client, err := NewClient(sc.PrometheusConfig(), sc.Logger())
 	if err != nil {


### PR DESCRIPTION
## Summary

PR #125 was admin-merged while the `golangci-lint` pre-commit hook was still failing, leaving `main`'s [pre-commit workflow red](https://github.com/giantswarm/mcp-prometheus/actions/runs/24829434181). This change fixes the 76 remaining violations at the source so `pre-commit run --all-files` exits 0 without any `--admin` shortcut.

### Changes by linter

- **errcheck (35)**: rewrite tests to use `t.Setenv` (auto-restores, no error to check); discard returns with `_, _ = ...` / `_ = ...`; wrap deferred `sc.Shutdown()` and `resp.Body.Close()` in discarding closures.
- **gosec G104 (13)**: replace `//nolint:errcheck` comments that gosec still flagged with explicit `_ = ...` discards, so no linter is silenced.
- **gosec G112**: set `ReadHeaderTimeout: 10 * time.Second` on the embedded HTTP server (`cmd/serve.go`) to close the Slowloris window.
- **goconst (5)**: extract `envTrue`, `statusError`, `apiQueryPath`, `tenantProdEU`, and `overwrittenMark` constants.
- **staticcheck ST1005 (18)**: lowercase the `"Prometheus client not initialized"` error strings to follow Go error-string convention.
- **staticcheck ST1023**: drop the redundant `http.RoundTripper` type annotation in `var roundTripper = http.DefaultTransport`.
- **staticcheck S1000**: collapse the single-case `select { case err := ... }` in `runStdioServer` to a direct channel receive.

Neither `.pre-commit-config.yaml` nor `.golangci.yml` was modified; no rules were silenced globally; no `zz_*` files were touched.

## Test plan

- [x] `golangci-lint run -E=gosec -E=goconst -E=govet --timeout=300s --max-same-issues=0 --max-issues-per-linter=0` → 0 issues
- [x] `go test ./...` → all packages pass
- [x] `go build ./...` → clean
- [x] `go vet ./...` → clean
- [x] `gofmt -l .` → clean
- [x] `goimports -l -local github.com/giantswarm/mcp-prometheus .` → clean
- [ ] CI `pre-commit` workflow green (verified post-push before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)