### PR TITLE
Truncate oversized output for 11 read-only Prometheus tools

### DIFF
--- a/internal/tools/prometheus/tools.go
+++ b/internal/tools/prometheus/tools.go
@@ -119,6 +119,74 @@ type ToolMiddleware func(
 	next func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error),
 ) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
 
+// adviceByTool maps each Prometheus tool to the advice text appended to its
+// truncated output. Tools that do not appear here fall back to bulkAdvice.
+var adviceByTool = map[string]string{
+	"execute_query":        TruncationAdvice,
+	"execute_range_query":  TruncationAdvice,
+	"get_metric_metadata":  discoveryAdvice,
+	"list_label_names":     discoveryAdvice,
+	"list_label_values":    discoveryAdvice,
+	"find_series":          discoveryAdvice,
+	"query_exemplars":      discoveryAdvice,
+	"get_targets_metadata": discoveryAdvice,
+	"get_targets":          bulkAdvice,
+	"get_rules":            bulkAdvice,
+	"get_alerts":           bulkAdvice,
+	"get_config":           bulkAdvice,
+	"get_tsdb_stats":       bulkAdvice,
+}
+
+// truncationMiddleware caps oversized TextContent in tool results at
+// MaxResultLength and appends per-tool advice. It is applied uniformly to
+// every registered Prometheus tool so individual handlers can return raw
+// formatted output without worrying about size.
+//
+// Honours the "unlimited": "true" request argument: when set, the middleware
+// returns the upstream result unchanged. This escape hatch is only documented
+// for execute_query / execute_range_query, but the middleware accepts it on
+// any tool.
+func truncationMiddleware(
+	name string,
+	next func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error),
+) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	advice, ok := adviceByTool[name]
+	if !ok {
+		advice = bulkAdvice
+	}
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		res, err := next(ctx, req)
+		if err != nil || res == nil {
+			return res, err
+		}
+		if isUnlimitedRequest(req) {
+			return res, nil
+		}
+		for i, c := range res.Content {
+			tc, ok := c.(mcp.TextContent)
+			if !ok || len(tc.Text) <= MaxResultLength {
+				continue
+			}
+			tc.Text = truncateWithAdvice(tc.Text, advice)
+			res.Content[i] = tc
+		}
+		return res, nil
+	}
+}
+
+// isUnlimitedRequest reports whether the caller passed "unlimited": "true"
+// in the tool arguments. The query tools advertise this as the escape hatch
+// to disable output truncation; it is harmless on tools that don't document
+// it.
+func isUnlimitedRequest(req mcp.CallToolRequest) bool {
+	args, ok := req.Params.Arguments.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	v, _ := args["unlimited"].(string)
+	return v == "true"
+}
+
 // Handler wrapper type for cleaner function signatures
 type PrometheusHandler func(ctx context.Context, request mcp.CallToolRequest, client *Client, sc *server.ServerContext) (*mcp.CallToolResult, error)
 
@@ -163,6 +231,7 @@ func registerPrometheusTools(s *mcpserver.MCPServer, client *Client, sc *server.
 	tool := mcp.NewTool(toolName, append(baseOptions, allOptions...)...)
 
 	h := withDynamicPrometheusClient(handler, client, sc)
+	h = truncationMiddleware(toolName, h)
 	for _, mw := range middleware {
 		h = mw(toolName, h)
 	}
@@ -281,16 +350,15 @@ func truncateWithAdvice(text, advice string) string {
 	return truncated + advice
 }
 
-// formatQueryResult formats the query result with truncation and user guidance
+// formatQueryResult formats the query result. When unlimited is set, a
+// warning prefix is added; otherwise the raw formatted result is returned and
+// truncationMiddleware applies the size cap downstream.
 func formatQueryResult(resultType string, result interface{}, unlimited bool) string {
 	resultStr := fmt.Sprintf("Query executed successfully.\nResult Type: %s\nResult: %+v", resultType, result)
-
 	if unlimited {
-		warningMsg := "⚠️  WARNING: Unlimited output enabled - this response may be very large and could impact performance.\n\n"
-		return warningMsg + resultStr
+		return "⚠️  WARNING: Unlimited output enabled - this response may be very large and could impact performance.\n\n" + resultStr
 	}
-
-	return truncateWithAdvice(resultStr, TruncationAdvice)
+	return resultStr
 }
 
 // Helper function to extract parameters
@@ -608,7 +676,7 @@ func handleGetMetricMetadata(ctx context.Context, request mcp.CallToolRequest, c
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: truncateWithAdvice(fmt.Sprintf("Metadata for metric '%s':\n%+v", metric, metadata), discoveryAdvice),
+				Text: fmt.Sprintf("Metadata for metric '%s':\n%+v", metric, metadata),
 			},
 		},
 	}, nil
@@ -643,7 +711,7 @@ func handleGetTargets(ctx context.Context, request mcp.CallToolRequest, client *
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: truncateWithAdvice(result, bulkAdvice),
+				Text: result,
 			},
 		},
 	}, nil
@@ -695,7 +763,7 @@ func handleListLabelNames(ctx context.Context, request mcp.CallToolRequest, clie
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: truncateWithAdvice(responseText, discoveryAdvice),
+				Text: responseText,
 			},
 		},
 	}, nil
@@ -763,7 +831,7 @@ func handleListLabelValues(ctx context.Context, request mcp.CallToolRequest, cli
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: truncateWithAdvice(responseText, discoveryAdvice),
+				Text: responseText,
 			},
 		},
 	}, nil
@@ -830,7 +898,7 @@ func handleFindSeries(ctx context.Context, request mcp.CallToolRequest, client *
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: truncateWithAdvice(responseText, discoveryAdvice),
+				Text: responseText,
 			},
 		},
 	}, nil
@@ -858,7 +926,7 @@ func handleGetRules(ctx context.Context, request mcp.CallToolRequest, client *Cl
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: truncateWithAdvice(fmt.Sprintf("Prometheus Rules:\n%+v", rules), bulkAdvice),
+				Text: fmt.Sprintf("Prometheus Rules:\n%+v", rules),
 			},
 		},
 	}, nil
@@ -886,7 +954,7 @@ func handleGetAlerts(ctx context.Context, request mcp.CallToolRequest, client *C
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: truncateWithAdvice(fmt.Sprintf("Active Alerts:\n%+v", alerts), bulkAdvice),
+				Text: fmt.Sprintf("Active Alerts:\n%+v", alerts),
 			},
 		},
 	}, nil
@@ -942,7 +1010,7 @@ func handleGetConfig(ctx context.Context, request mcp.CallToolRequest, client *C
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: truncateWithAdvice(fmt.Sprintf("Prometheus Configuration:\n%+v", config), bulkAdvice),
+				Text: fmt.Sprintf("Prometheus Configuration:\n%+v", config),
 			},
 		},
 	}, nil
@@ -1059,7 +1127,7 @@ func handleGetTSDBStats(ctx context.Context, request mcp.CallToolRequest, client
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: truncateWithAdvice(fmt.Sprintf("TSDB Statistics:\n%+v", tsdbStats), bulkAdvice),
+				Text: fmt.Sprintf("TSDB Statistics:\n%+v", tsdbStats),
 			},
 		},
 	}, nil
@@ -1127,7 +1195,7 @@ func handleQueryExemplars(ctx context.Context, request mcp.CallToolRequest, clie
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: truncateWithAdvice(fmt.Sprintf("Exemplars for query '%s':\n%+v", query, exemplars), discoveryAdvice),
+				Text: fmt.Sprintf("Exemplars for query '%s':\n%+v", query, exemplars),
 			},
 		},
 	}, nil
@@ -1160,7 +1228,7 @@ func handleGetTargetsMetadata(ctx context.Context, request mcp.CallToolRequest, 
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: truncateWithAdvice(fmt.Sprintf("Targets Metadata:\n%+v", targetsMetadata), discoveryAdvice),
+				Text: fmt.Sprintf("Targets Metadata:\n%+v", targetsMetadata),
 			},
 		},
 	}, nil

--- a/internal/tools/prometheus/tools.go
+++ b/internal/tools/prometheus/tools.go
@@ -138,21 +138,25 @@ type ToolMiddleware func(
 	next func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error),
 ) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
 
-// unlimitedAllowed is the closed set of tool names where the caller may pass
-// "unlimited": "true" to bypass truncation. Limiting this prevents callers
-// who learned the trick from execute_query's description from silently
-// disabling the cap on bulk-dump tools that have no other safety valve.
-var unlimitedAllowed = map[string]bool{
-	"execute_query":       true,
-	"execute_range_query": true,
+// allowsUnlimited reports whether the named tool honours the
+// "unlimited": "true" request argument. The set is closed and static —
+// limiting it prevents callers who learned the trick from execute_query's
+// description from silently disabling the cap on bulk-dump tools that have
+// no other safety valve.
+func allowsUnlimited(name string) bool {
+	switch name {
+	case "execute_query", "execute_range_query":
+		return true
+	}
+	return false
 }
 
 // truncationMiddleware caps oversized TextContent in tool results at
 // MaxResultLength and appends the given advice. It is wired by
 // registerPrometheusTools for every tool whose advice argument is non-empty.
 //
-// Honours the "unlimited": "true" request argument only on the tools listed
-// in unlimitedAllowed; other tools cannot opt out of truncation.
+// Honours the "unlimited": "true" request argument only on the tools that
+// allowsUnlimited returns true for; other tools cannot opt out of truncation.
 func truncationMiddleware(
 	name, advice string,
 	next func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error),
@@ -162,7 +166,7 @@ func truncationMiddleware(
 		if err != nil || res == nil {
 			return res, err
 		}
-		if unlimitedAllowed[name] && isUnlimitedRequest(req) {
+		if allowsUnlimited(name) && isUnlimitedRequest(req) {
 			return res, nil
 		}
 		// res.Content is freshly allocated by every handler in this package, so
@@ -182,7 +186,7 @@ func truncationMiddleware(
 
 // isUnlimitedRequest reports whether the caller passed "unlimited": "true"
 // in the tool arguments. Whether the bypass is honoured depends on the tool;
-// see unlimitedAllowed.
+// see allowsUnlimited.
 func isUnlimitedRequest(req mcp.CallToolRequest) bool {
 	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {

--- a/internal/tools/prometheus/tools.go
+++ b/internal/tools/prometheus/tools.go
@@ -487,8 +487,7 @@ func handleExecuteQuery(ctx context.Context, request mcp.CallToolRequest, client
 	}
 
 	timeParam, _ := params["time"].(string)
-	unlimitedStr, _ := params["unlimited"].(string)
-	unlimited := unlimitedStr == "true"
+	unlimited := isUnlimitedRequest(request)
 
 	// Extract new optional parameters
 	options := QueryOptions{
@@ -589,8 +588,7 @@ func handleExecuteRangeQuery(ctx context.Context, request mcp.CallToolRequest, c
 			},
 		}, nil
 	}
-	unlimitedStr, _ := params["unlimited"].(string)
-	unlimited := unlimitedStr == "true"
+	unlimited := isUnlimitedRequest(request)
 
 	// Extract new optional parameters
 	options := QueryOptions{

--- a/internal/tools/prometheus/tools.go
+++ b/internal/tools/prometheus/tools.go
@@ -28,6 +28,32 @@ const (
    • Filtering by specific metrics instead of using wildcards
 
 🔧 To get the full untruncated result, add "unlimited": "true" to your query parameters, but be aware this may impact performance.`
+
+	// discoveryAdvice is appended when label/series/metadata/exemplar tool
+	// output is truncated. These tools accept matchers, time windows and
+	// limits, so the advice nudges the caller toward narrower requests.
+	discoveryAdvice = `
+
+⚠️  RESULT TRUNCATED: The response exceeded 50k characters.
+
+💡 To get a smaller, more focused result, consider:
+   • Passing a tighter "matches" selector (e.g. {namespace="my-ns", job="my-job"})
+   • Narrowing the "start_time" / "end_time" window
+   • Setting an explicit "limit" parameter
+   • Querying a specific metric name instead of broad patterns`
+
+	// bulkAdvice is appended when output from tools that dump system-wide
+	// state (rules, targets, config, alerts, TSDB stats) is truncated. These
+	// tools have no filtering parameters, so the advice points at narrower
+	// alternatives.
+	bulkAdvice = `
+
+⚠️  RESULT TRUNCATED: The response exceeded 50k characters.
+
+💡 This tool returns a full, unfiltered server dump. To inspect a smaller slice, consider:
+   • Using "execute_query" with ALERTS{alertname="..."} for specific alerts
+   • Using "find_series" with label matchers to scope to a job, namespace, or pool
+   • Using "get_targets_metadata" with "match_target" / "metric" filters`
 )
 
 // Common parameter builders to reduce repetition
@@ -241,6 +267,20 @@ func RegisterPrometheusTools(s *mcpserver.MCPServer, sc *server.ServerContext, m
 	return nil
 }
 
+// truncateWithAdvice trims text to MaxResultLength and appends the given
+// advice when truncation occurs. It tries to end at the last newline within
+// the trailing 1000 bytes to avoid cutting mid-line.
+func truncateWithAdvice(text, advice string) string {
+	if len(text) <= MaxResultLength {
+		return text
+	}
+	truncated := text[:MaxResultLength]
+	if lastNewline := strings.LastIndex(truncated, "\n"); lastNewline > MaxResultLength-1000 {
+		truncated = truncated[:lastNewline]
+	}
+	return truncated + advice
+}
+
 // formatQueryResult formats the query result with truncation and user guidance
 func formatQueryResult(resultType string, result interface{}, unlimited bool) string {
 	resultStr := fmt.Sprintf("Query executed successfully.\nResult Type: %s\nResult: %+v", resultType, result)
@@ -250,16 +290,7 @@ func formatQueryResult(resultType string, result interface{}, unlimited bool) st
 		return warningMsg + resultStr
 	}
 
-	if len(resultStr) > MaxResultLength {
-		truncated := resultStr[:MaxResultLength]
-		// Try to end at a complete line to avoid cutting off mid-metric
-		if lastNewline := strings.LastIndex(truncated, "\n"); lastNewline > MaxResultLength-1000 {
-			truncated = truncated[:lastNewline]
-		}
-		return truncated + TruncationAdvice
-	}
-
-	return resultStr
+	return truncateWithAdvice(resultStr, TruncationAdvice)
 }
 
 // Helper function to extract parameters
@@ -577,7 +608,7 @@ func handleGetMetricMetadata(ctx context.Context, request mcp.CallToolRequest, c
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: fmt.Sprintf("Metadata for metric '%s':\n%+v", metric, metadata),
+				Text: truncateWithAdvice(fmt.Sprintf("Metadata for metric '%s':\n%+v", metric, metadata), discoveryAdvice),
 			},
 		},
 	}, nil
@@ -612,7 +643,7 @@ func handleGetTargets(ctx context.Context, request mcp.CallToolRequest, client *
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: result,
+				Text: truncateWithAdvice(result, bulkAdvice),
 			},
 		},
 	}, nil
@@ -664,7 +695,7 @@ func handleListLabelNames(ctx context.Context, request mcp.CallToolRequest, clie
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: responseText,
+				Text: truncateWithAdvice(responseText, discoveryAdvice),
 			},
 		},
 	}, nil
@@ -732,7 +763,7 @@ func handleListLabelValues(ctx context.Context, request mcp.CallToolRequest, cli
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: responseText,
+				Text: truncateWithAdvice(responseText, discoveryAdvice),
 			},
 		},
 	}, nil
@@ -799,7 +830,7 @@ func handleFindSeries(ctx context.Context, request mcp.CallToolRequest, client *
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: responseText,
+				Text: truncateWithAdvice(responseText, discoveryAdvice),
 			},
 		},
 	}, nil
@@ -827,7 +858,7 @@ func handleGetRules(ctx context.Context, request mcp.CallToolRequest, client *Cl
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: fmt.Sprintf("Prometheus Rules:\n%+v", rules),
+				Text: truncateWithAdvice(fmt.Sprintf("Prometheus Rules:\n%+v", rules), bulkAdvice),
 			},
 		},
 	}, nil
@@ -855,7 +886,7 @@ func handleGetAlerts(ctx context.Context, request mcp.CallToolRequest, client *C
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: fmt.Sprintf("Active Alerts:\n%+v", alerts),
+				Text: truncateWithAdvice(fmt.Sprintf("Active Alerts:\n%+v", alerts), bulkAdvice),
 			},
 		},
 	}, nil
@@ -911,7 +942,7 @@ func handleGetConfig(ctx context.Context, request mcp.CallToolRequest, client *C
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: fmt.Sprintf("Prometheus Configuration:\n%+v", config),
+				Text: truncateWithAdvice(fmt.Sprintf("Prometheus Configuration:\n%+v", config), bulkAdvice),
 			},
 		},
 	}, nil
@@ -1028,7 +1059,7 @@ func handleGetTSDBStats(ctx context.Context, request mcp.CallToolRequest, client
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: fmt.Sprintf("TSDB Statistics:\n%+v", tsdbStats),
+				Text: truncateWithAdvice(fmt.Sprintf("TSDB Statistics:\n%+v", tsdbStats), bulkAdvice),
 			},
 		},
 	}, nil
@@ -1096,7 +1127,7 @@ func handleQueryExemplars(ctx context.Context, request mcp.CallToolRequest, clie
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: fmt.Sprintf("Exemplars for query '%s':\n%+v", query, exemplars),
+				Text: truncateWithAdvice(fmt.Sprintf("Exemplars for query '%s':\n%+v", query, exemplars), discoveryAdvice),
 			},
 		},
 	}, nil
@@ -1129,7 +1160,7 @@ func handleGetTargetsMetadata(ctx context.Context, request mcp.CallToolRequest, 
 		Content: []mcp.Content{
 			mcp.TextContent{
 				Type: "text",
-				Text: fmt.Sprintf("Targets Metadata:\n%+v", targetsMetadata),
+				Text: truncateWithAdvice(fmt.Sprintf("Targets Metadata:\n%+v", targetsMetadata), discoveryAdvice),
 			},
 		},
 	}, nil

--- a/internal/tools/prometheus/tools.go
+++ b/internal/tools/prometheus/tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	mcpoauth "github.com/giantswarm/mcp-oauth"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -42,18 +43,36 @@ const (
    • Setting an explicit "limit" parameter
    • Querying a specific metric name instead of broad patterns`
 
-	// bulkAdvice is appended when output from tools that dump system-wide
-	// state (rules, targets, config, alerts, TSDB stats) is truncated. These
-	// tools have no filtering parameters, so the advice points at narrower
-	// alternatives.
+	// alertsAdvice is appended when get_alerts output is truncated. The
+	// ALERTS series is queryable via PromQL, so the advice points the caller
+	// at execute_query with a narrower selector.
+	alertsAdvice = `
+
+⚠️  RESULT TRUNCATED: The response exceeded 50k characters.
+
+💡 To narrow the result, query the ALERTS series directly via "execute_query":
+   • execute_query with ALERTS{alertname="..."} to inspect a specific alert
+   • execute_query with ALERTS{severity="critical"} to filter by label
+   • Combine with topk() / count() to summarise rather than enumerate`
+
+	// bulkAdvice is appended when tools that return server-wide state are
+	// truncated and there is no narrower API on the Prometheus/Mimir side
+	// (get_rules, get_targets, get_config, get_tsdb_stats). The honest answer
+	// is "fetch less or filter on the client side."
 	bulkAdvice = `
 
 ⚠️  RESULT TRUNCATED: The response exceeded 50k characters.
 
-💡 This tool returns a full, unfiltered server dump. To inspect a smaller slice, consider:
-   • Using "execute_query" with ALERTS{alertname="..."} for specific alerts
-   • Using "find_series" with label matchers to scope to a job, namespace, or pool
-   • Using "get_targets_metadata" with "match_target" / "metric" filters`
+💡 This tool returns the full server-side state and has no narrower API. Options:
+   • If the tool exposes a "limit" parameter, pass one
+   • Re-run against a more focused tenant/org scope
+   • Fetch less often and filter or paginate on the client side`
+
+	// noTruncation, when passed as the advice argument to
+	// registerPrometheusTools, disables the truncation middleware for that
+	// tool. Use it for tools whose output is bounded in practice
+	// (get_build_info, get_flags, …).
+	noTruncation = ""
 )
 
 // Common parameter builders to reduce repetition
@@ -119,49 +138,36 @@ type ToolMiddleware func(
 	next func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error),
 ) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
 
-// adviceByTool maps each Prometheus tool to the advice text appended to its
-// truncated output. Tools that do not appear here fall back to bulkAdvice.
-var adviceByTool = map[string]string{
-	"execute_query":        TruncationAdvice,
-	"execute_range_query":  TruncationAdvice,
-	"get_metric_metadata":  discoveryAdvice,
-	"list_label_names":     discoveryAdvice,
-	"list_label_values":    discoveryAdvice,
-	"find_series":          discoveryAdvice,
-	"query_exemplars":      discoveryAdvice,
-	"get_targets_metadata": discoveryAdvice,
-	"get_targets":          bulkAdvice,
-	"get_rules":            bulkAdvice,
-	"get_alerts":           bulkAdvice,
-	"get_config":           bulkAdvice,
-	"get_tsdb_stats":       bulkAdvice,
+// unlimitedAllowed is the closed set of tool names where the caller may pass
+// "unlimited": "true" to bypass truncation. Limiting this prevents callers
+// who learned the trick from execute_query's description from silently
+// disabling the cap on bulk-dump tools that have no other safety valve.
+var unlimitedAllowed = map[string]bool{
+	"execute_query":       true,
+	"execute_range_query": true,
 }
 
 // truncationMiddleware caps oversized TextContent in tool results at
-// MaxResultLength and appends per-tool advice. It is applied uniformly to
-// every registered Prometheus tool so individual handlers can return raw
-// formatted output without worrying about size.
+// MaxResultLength and appends the given advice. It is wired by
+// registerPrometheusTools for every tool whose advice argument is non-empty.
 //
-// Honours the "unlimited": "true" request argument: when set, the middleware
-// returns the upstream result unchanged. This escape hatch is only documented
-// for execute_query / execute_range_query, but the middleware accepts it on
-// any tool.
+// Honours the "unlimited": "true" request argument only on the tools listed
+// in unlimitedAllowed; other tools cannot opt out of truncation.
 func truncationMiddleware(
-	name string,
+	name, advice string,
 	next func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error),
 ) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	advice, ok := adviceByTool[name]
-	if !ok {
-		advice = bulkAdvice
-	}
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		res, err := next(ctx, req)
 		if err != nil || res == nil {
 			return res, err
 		}
-		if isUnlimitedRequest(req) {
+		if unlimitedAllowed[name] && isUnlimitedRequest(req) {
 			return res, nil
 		}
+		// res.Content is freshly allocated by every handler in this package, so
+		// in-place mutation is safe. If a future handler ever returns a shared
+		// slice, clone here before writing.
 		for i, c := range res.Content {
 			tc, ok := c.(mcp.TextContent)
 			if !ok || len(tc.Text) <= MaxResultLength {
@@ -175,11 +181,10 @@ func truncationMiddleware(
 }
 
 // isUnlimitedRequest reports whether the caller passed "unlimited": "true"
-// in the tool arguments. The query tools advertise this as the escape hatch
-// to disable output truncation; it is harmless on tools that don't document
-// it.
+// in the tool arguments. Whether the bypass is honoured depends on the tool;
+// see unlimitedAllowed.
 func isUnlimitedRequest(req mcp.CallToolRequest) bool {
-	args, ok := req.Params.Arguments.(map[string]interface{})
+	args, ok := req.Params.Arguments.(map[string]any)
 	if !ok {
 		return false
 	}
@@ -221,7 +226,7 @@ func withDynamicPrometheusClient(handler PrometheusHandler, client *Client, sc *
 // than the open web, so readOnlyHint is always true and openWorldHint is always
 // false. destructiveHint and idempotentHint are omitted because they are only
 // meaningful when readOnlyHint is false.
-func registerPrometheusTools(s *mcpserver.MCPServer, client *Client, sc *server.ServerContext, middleware []ToolMiddleware, toolName string, description string, handler PrometheusHandler, options ...mcp.ToolOption) {
+func registerPrometheusTools(s *mcpserver.MCPServer, client *Client, sc *server.ServerContext, middleware []ToolMiddleware, toolName string, description string, advice string, handler PrometheusHandler, options ...mcp.ToolOption) {
 	allOptions := withPrometheusConnectionParams(options...)
 	baseOptions := []mcp.ToolOption{
 		mcp.WithDescription(description),
@@ -231,7 +236,11 @@ func registerPrometheusTools(s *mcpserver.MCPServer, client *Client, sc *server.
 	tool := mcp.NewTool(toolName, append(baseOptions, allOptions...)...)
 
 	h := withDynamicPrometheusClient(handler, client, sc)
-	h = truncationMiddleware(toolName, h)
+	if advice != noTruncation {
+		h = truncationMiddleware(toolName, advice, h)
+	}
+	// User-supplied middlewares wrap the (possibly already truncated) result,
+	// so any telemetry middleware sees post-truncation byte counts.
 	for _, mw := range middleware {
 		h = mw(toolName, h)
 	}
@@ -254,13 +263,13 @@ func RegisterPrometheusTools(s *mcpserver.MCPServer, sc *server.ServerContext, m
 
 	// Query execution tools
 	registerPrometheusTools(s, client, sc, middleware, "execute_query", "Execute a PromQL instant query against Prometheus",
-		handleExecuteQuery, withQueryEnhancementParams(
+		TruncationAdvice, handleExecuteQuery, withQueryEnhancementParams(
 			mcp.WithString("query", mcp.Required(), mcp.Description("PromQL query string")),
 			mcp.WithString("time", mcp.Description("Optional RFC3339 or Unix timestamp (default: current time)")),
 		)...)
 
 	registerPrometheusTools(s, client, sc, middleware, "execute_range_query", "Execute a PromQL range query with start time, end time, and step interval",
-		handleExecuteRangeQuery, withQueryEnhancementParams(
+		TruncationAdvice, handleExecuteRangeQuery, withQueryEnhancementParams(
 			mcp.WithString("query", mcp.Required(), mcp.Description("PromQL query string")),
 			mcp.WithString("start", mcp.Required(), mcp.Description("Start time as RFC3339 or Unix timestamp")),
 			mcp.WithString("end", mcp.Required(), mcp.Description("End time as RFC3339 or Unix timestamp")),
@@ -269,76 +278,79 @@ func RegisterPrometheusTools(s *mcpserver.MCPServer, sc *server.ServerContext, m
 
 	// Metrics discovery tools
 	registerPrometheusTools(s, client, sc, middleware, "get_metric_metadata", "Get metadata for a specific metric",
-		handleGetMetricMetadata,
+		discoveryAdvice, handleGetMetricMetadata,
 		mcp.WithString("metric", mcp.Required(), mcp.Description("The name of the metric to retrieve metadata for")),
 		mcp.WithString("limit", mcp.Description("Maximum number of metadata entries to return")),
 	)
 
 	// Label and series discovery tools
 	registerPrometheusTools(s, client, sc, middleware, "list_label_names", "Get all available label names",
-		handleListLabelNames, withTimeFilteringParams(withLabelMatchingParams(
+		discoveryAdvice, handleListLabelNames, withTimeFilteringParams(withLabelMatchingParams(
 			mcp.WithString("limit", mcp.Description("Maximum number of label names to return")),
 		)...)...)
 
 	registerPrometheusTools(s, client, sc, middleware, "list_label_values", "Get values for a specific label",
-		handleListLabelValues, withTimeFilteringParams(withLabelMatchingParams(
+		discoveryAdvice, handleListLabelValues, withTimeFilteringParams(withLabelMatchingParams(
 			mcp.WithString("label", mcp.Required(), mcp.Description("The label name to get values for")),
 			mcp.WithString("limit", mcp.Description("Maximum number of label values to return")),
 		)...)...)
 
 	registerPrometheusTools(s, client, sc, middleware, "find_series", "Find series by label matchers",
-		handleFindSeries, withTimeFilteringParams(
+		discoveryAdvice, handleFindSeries, withTimeFilteringParams(
 			mcp.WithArray("matches", mcp.Required(), mcp.Description("Array of label matchers (e.g., ['{job=\"prometheus\"}', '{__name__=~\"http_.*\"}'])")),
 			mcp.WithString("limit", mcp.Description("Maximum number of series to return")),
 		)...)
 
 	// Target and system information tools
-	registerPrometheusTools(s, client, sc, middleware, "get_targets", "Get information about all scrape targets", handleGetTargets)
+	registerPrometheusTools(s, client, sc, middleware, "get_targets", "Get information about all scrape targets", bulkAdvice, handleGetTargets)
 
-	registerPrometheusTools(s, client, sc, middleware, "get_build_info", "Get build information about the Prometheus server", handleGetBuildInfo)
+	registerPrometheusTools(s, client, sc, middleware, "get_build_info", "Get build information about the Prometheus server", noTruncation, handleGetBuildInfo)
 
-	registerPrometheusTools(s, client, sc, middleware, "get_runtime_info", "Get runtime information about the Prometheus server", handleGetRuntimeInfo)
+	registerPrometheusTools(s, client, sc, middleware, "get_runtime_info", "Get runtime information about the Prometheus server", noTruncation, handleGetRuntimeInfo)
 
-	registerPrometheusTools(s, client, sc, middleware, "get_flags", "Get runtime flags that Prometheus was launched with", handleGetFlags)
+	registerPrometheusTools(s, client, sc, middleware, "get_flags", "Get runtime flags that Prometheus was launched with", noTruncation, handleGetFlags)
 
-	registerPrometheusTools(s, client, sc, middleware, "get_config", "Get Prometheus configuration", handleGetConfig)
+	registerPrometheusTools(s, client, sc, middleware, "get_config", "Get Prometheus configuration", bulkAdvice, handleGetConfig)
 
 	// Alerting tools
-	registerPrometheusTools(s, client, sc, middleware, "get_alerts", "Get active alerts", handleGetAlerts)
+	registerPrometheusTools(s, client, sc, middleware, "get_alerts", "Get active alerts", alertsAdvice, handleGetAlerts)
 
-	registerPrometheusTools(s, client, sc, middleware, "get_alertmanagers", "Get AlertManager discovery information", handleGetAlertManagers)
+	registerPrometheusTools(s, client, sc, middleware, "get_alertmanagers", "Get AlertManager discovery information", noTruncation, handleGetAlertManagers)
 
-	registerPrometheusTools(s, client, sc, middleware, "get_rules", "Get recording and alerting rules", handleGetRules)
+	registerPrometheusTools(s, client, sc, middleware, "get_rules", "Get recording and alerting rules", bulkAdvice, handleGetRules)
 
 	// Advanced tools
 	registerPrometheusTools(s, client, sc, middleware, "get_tsdb_stats", "Get TSDB cardinality statistics",
-		handleGetTSDBStats,
+		bulkAdvice, handleGetTSDBStats,
 		mcp.WithString("limit", mcp.Description("Maximum number of stats entries to return")),
 	)
 
 	registerPrometheusTools(s, client, sc, middleware, "query_exemplars", "Query exemplars for traces",
-		handleQueryExemplars,
+		discoveryAdvice, handleQueryExemplars,
 		mcp.WithString("query", mcp.Required(), mcp.Description("PromQL query string to find exemplars for")),
 		mcp.WithString("start", mcp.Required(), mcp.Description("Start time as RFC3339 or Unix timestamp")),
 		mcp.WithString("end", mcp.Required(), mcp.Description("End time as RFC3339 or Unix timestamp")),
 	)
 
 	registerPrometheusTools(s, client, sc, middleware, "get_targets_metadata", "Get metadata about metrics from specific targets",
-		handleGetTargetsMetadata,
+		discoveryAdvice, handleGetTargetsMetadata,
 		mcp.WithString("match_target", mcp.Description("Target matcher to filter targets")),
 		mcp.WithString("metric", mcp.Description("Metric name to filter metadata for")),
 		mcp.WithString("limit", mcp.Description("Maximum number of metadata entries to return")),
 	)
 
 	// Status / health tools
-	registerPrometheusTools(s, client, sc, middleware, "check_ready", "Check whether the Prometheus/Mimir server is ready to serve traffic (GET /-/ready)", handleCheckReady)
+	registerPrometheusTools(s, client, sc, middleware, "check_ready", "Check whether the Prometheus/Mimir server is ready to serve traffic (GET /-/ready)", noTruncation, handleCheckReady)
 
 	return nil
 }
 
 // truncateWithAdvice trims text to MaxResultLength and appends the given
 // advice when truncation occurs. It tries to end at the last newline within
-// the trailing 1000 bytes to avoid cutting mid-line.
+// the trailing 1000 bytes to avoid cutting mid-line, and backs off any
+// half-rune at the cut so the result remains valid UTF-8 (the advice strings
+// start with multi-byte characters, so a half-rune tail would corrupt the
+// JSON encoding downstream).
 func truncateWithAdvice(text, advice string) string {
 	if len(text) <= MaxResultLength {
 		return text
@@ -346,6 +358,12 @@ func truncateWithAdvice(text, advice string) string {
 	truncated := text[:MaxResultLength]
 	if lastNewline := strings.LastIndex(truncated, "\n"); lastNewline > MaxResultLength-1000 {
 		truncated = truncated[:lastNewline]
+	} else {
+		// No usable newline anchor — the byte cut may sit mid-rune. UTF-8
+		// runes are at most 4 bytes, so up to 3 backoff steps suffice.
+		for i := 0; i < utf8.UTFMax-1 && len(truncated) > 0 && !utf8.ValidString(truncated); i++ {
+			truncated = truncated[:len(truncated)-1]
+		}
 	}
 	return truncated + advice
 }
@@ -353,7 +371,7 @@ func truncateWithAdvice(text, advice string) string {
 // formatQueryResult formats the query result. When unlimited is set, a
 // warning prefix is added; otherwise the raw formatted result is returned and
 // truncationMiddleware applies the size cap downstream.
-func formatQueryResult(resultType string, result interface{}, unlimited bool) string {
+func formatQueryResult(resultType string, result any, unlimited bool) string {
 	resultStr := fmt.Sprintf("Query executed successfully.\nResult Type: %s\nResult: %+v", resultType, result)
 	if unlimited {
 		return "⚠️  WARNING: Unlimited output enabled - this response may be very large and could impact performance.\n\n" + resultStr
@@ -362,10 +380,10 @@ func formatQueryResult(resultType string, result interface{}, unlimited bool) st
 }
 
 // Helper function to extract parameters
-func extractParams(request mcp.CallToolRequest) map[string]interface{} {
-	params := make(map[string]interface{})
+func extractParams(request mcp.CallToolRequest) map[string]any {
+	params := make(map[string]any)
 	if request.Params.Arguments != nil {
-		if argsMap, ok := request.Params.Arguments.(map[string]interface{}); ok {
+		if argsMap, ok := request.Params.Arguments.(map[string]any); ok {
 			params = argsMap
 		}
 	}
@@ -373,9 +391,9 @@ func extractParams(request mcp.CallToolRequest) map[string]interface{} {
 }
 
 // Helper function to extract string array parameter
-func extractStringArray(params map[string]interface{}, key string) []string {
+func extractStringArray(params map[string]any, key string) []string {
 	if val, ok := params[key]; ok {
-		if arr, ok := val.([]interface{}); ok {
+		if arr, ok := val.([]any); ok {
 			result := make([]string, 0, len(arr))
 			for _, item := range arr {
 				if str, ok := item.(string); ok {
@@ -421,7 +439,7 @@ func resolveTenantOrgID(ctx context.Context, sc *server.ServerContext, explicit 
 
 // createClientFromParams creates a Prometheus client from request parameters,
 // applying OAuth tenancy resolution for the X-Scope-OrgID header when enabled.
-func createClientFromParams(ctx context.Context, params map[string]interface{}, defaultClient *Client, sc *server.ServerContext) (*Client, error) {
+func createClientFromParams(ctx context.Context, params map[string]any, defaultClient *Client, sc *server.ServerContext) (*Client, error) {
 	prometheusURL, hasURL := params["prometheus_url"].(string)
 	explicitOrgID, _ := params["org_id"].(string)
 
@@ -1263,7 +1281,7 @@ func handleCheckReady(ctx context.Context, request mcp.CallToolRequest, client *
 }
 
 // Helper function to safely get string parameter
-func getStringParam(params map[string]interface{}, key string) string {
+func getStringParam(params map[string]any, key string) string {
 	if val, ok := params[key].(string); ok {
 		return val
 	}

--- a/internal/tools/prometheus/tools_test.go
+++ b/internal/tools/prometheus/tools_test.go
@@ -596,7 +596,7 @@ func TestTruncateWithAdvice(t *testing.T) {
 
 func TestHandleListLabelNamesTruncation(t *testing.T) {
 	// Stub /api/v1/labels with enough names to push the formatted response
-	// past MaxResultLength so the byte cap fires.
+	// past MaxResultLength so the middleware cap fires.
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/labels" {
 			w.WriteHeader(http.StatusNotFound)
@@ -629,7 +629,12 @@ func TestHandleListLabelNamesTruncation(t *testing.T) {
 		t.Fatalf("NewClient: %v", err)
 	}
 
-	result, err := handleListLabelNames(ctx, mcp.CallToolRequest{}, client, sc)
+	// Exercise the production path: handler wrapped by truncationMiddleware.
+	h := truncationMiddleware("list_label_names", func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleListLabelNames(ctx, req, client, sc)
+	})
+
+	result, err := h(ctx, mcp.CallToolRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -654,4 +659,93 @@ func TestHandleListLabelNamesTruncation(t *testing.T) {
 	if !strings.HasSuffix(tc.Text, discoveryAdvice) {
 		t.Errorf("expected discoveryAdvice suffix; tail=%q", tc.Text[max(0, len(tc.Text)-120):])
 	}
+}
+
+func TestTruncationMiddleware(t *testing.T) {
+	bigText := strings.Repeat("x", MaxResultLength+500)
+	smallText := "ok"
+
+	makeHandler := func(text string) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: text}},
+			}, nil
+		}
+	}
+
+	t.Run("truncates oversized output and appends the tool's advice", func(t *testing.T) {
+		h := truncationMiddleware("find_series", makeHandler(bigText))
+		res, err := h(context.Background(), mcp.CallToolRequest{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := res.Content[0].(mcp.TextContent).Text
+		if !strings.HasSuffix(got, discoveryAdvice) {
+			t.Errorf("expected discoveryAdvice suffix for find_series")
+		}
+		if len(got) > MaxResultLength+len(discoveryAdvice) {
+			t.Errorf("truncated text longer than expected: %d", len(got))
+		}
+	})
+
+	t.Run("unmapped tool falls back to bulkAdvice", func(t *testing.T) {
+		h := truncationMiddleware("not_a_real_tool", makeHandler(bigText))
+		res, _ := h(context.Background(), mcp.CallToolRequest{})
+		got := res.Content[0].(mcp.TextContent).Text
+		if !strings.HasSuffix(got, bulkAdvice) {
+			t.Errorf("expected bulkAdvice fallback for unmapped tool")
+		}
+	})
+
+	t.Run("short text passes through untouched", func(t *testing.T) {
+		h := truncationMiddleware("execute_query", makeHandler(smallText))
+		res, _ := h(context.Background(), mcp.CallToolRequest{})
+		got := res.Content[0].(mcp.TextContent).Text
+		if got != smallText {
+			t.Errorf("expected passthrough %q, got %q", smallText, got)
+		}
+	})
+
+	t.Run("unlimited=true bypasses truncation", func(t *testing.T) {
+		h := truncationMiddleware("execute_query", makeHandler(bigText))
+		req := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name:      "execute_query",
+				Arguments: map[string]interface{}{"unlimited": "true"},
+			},
+		}
+		res, _ := h(context.Background(), req)
+		got := res.Content[0].(mcp.TextContent).Text
+		if got != bigText {
+			t.Errorf("expected raw bigText with unlimited=true; len got=%d, want=%d", len(got), len(bigText))
+		}
+	})
+
+	t.Run("propagates handler errors without modification", func(t *testing.T) {
+		boom := fmt.Errorf("boom")
+		h := truncationMiddleware("execute_query", func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return nil, boom
+		})
+		_, err := h(context.Background(), mcp.CallToolRequest{})
+		if err != boom {
+			t.Errorf("expected boom propagated, got %v", err)
+		}
+	})
+
+	t.Run("preserves IsError flag on tool error results", func(t *testing.T) {
+		h := truncationMiddleware("execute_query", func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: bigText}},
+			}, nil
+		})
+		res, _ := h(context.Background(), mcp.CallToolRequest{})
+		if !res.IsError {
+			t.Error("expected IsError=true to be preserved")
+		}
+		got := res.Content[0].(mcp.TextContent).Text
+		if !strings.HasSuffix(got, TruncationAdvice) {
+			t.Error("expected truncation to still apply to error results")
+		}
+	})
 }

--- a/internal/tools/prometheus/tools_test.go
+++ b/internal/tools/prometheus/tools_test.go
@@ -555,3 +555,103 @@ func TestHandleCheckReadyConnectionError(t *testing.T) {
 		t.Error("expected IsError=true for connection failure")
 	}
 }
+
+func TestTruncateWithAdvice(t *testing.T) {
+	const advice = "ADV"
+
+	t.Run("under cap returns input verbatim", func(t *testing.T) {
+		in := "small payload"
+		if got := truncateWithAdvice(in, advice); got != in {
+			t.Errorf("expected passthrough, got %q", got)
+		}
+	})
+
+	t.Run("over cap with no nearby newline cuts at MaxResultLength", func(t *testing.T) {
+		in := strings.Repeat("a", MaxResultLength+50)
+		got := truncateWithAdvice(in, advice)
+		if want := MaxResultLength + len(advice); len(got) != want {
+			t.Errorf("expected total length %d, got %d", want, len(got))
+		}
+		if !strings.HasSuffix(got, advice) {
+			t.Errorf("expected advice suffix, got tail %q", got[len(got)-len(advice):])
+		}
+	})
+
+	t.Run("over cap with newline in trailing 1000 bytes cuts at newline", func(t *testing.T) {
+		// Place a newline 50 bytes before MaxResultLength, then more content.
+		head := strings.Repeat("a", MaxResultLength-50)
+		in := head + "\n" + strings.Repeat("b", 200)
+		got := truncateWithAdvice(in, advice)
+		if want := (MaxResultLength - 50) + len(advice); len(got) != want {
+			t.Errorf("expected total length %d (cut at newline), got %d", want, len(got))
+		}
+		if !strings.HasPrefix(got, head) {
+			t.Errorf("expected payload to start with head; got prefix %q", got[:20])
+		}
+		if !strings.HasSuffix(got, advice) {
+			t.Errorf("expected advice suffix, got tail %q", got[len(got)-len(advice):])
+		}
+	})
+}
+
+func TestHandleListLabelNamesTruncation(t *testing.T) {
+	// Stub /api/v1/labels with enough names to push the formatted response
+	// past MaxResultLength so the byte cap fires.
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/labels" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		names := make([]string, 6000)
+		for i := range names {
+			names[i] = fmt.Sprintf("label_%05d", i)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"status": "success",
+			"data":   names,
+		})
+	}))
+	defer mockServer.Close()
+
+	ctx := context.Background()
+	sc, err := server.NewServerContext(ctx,
+		server.WithPrometheusConfig(server.PrometheusConfig{URL: mockServer.URL}),
+		server.WithSlogLogger(discardLogger()),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create server context: %v", err)
+	}
+	defer func() { _ = sc.Shutdown() }()
+
+	client, err := NewClient(sc.PrometheusConfig(), sc.Logger())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	result, err := handleListLabelNames(ctx, mcp.CallToolRequest{}, client, sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected at least one content block")
+	}
+	tc, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+
+	// The formatted body itself must not exceed MaxResultLength; the appended
+	// advice is allowed to push the total slightly past it.
+	body := strings.TrimSuffix(tc.Text, discoveryAdvice)
+	if len(body) > MaxResultLength {
+		t.Errorf("formatted body exceeds cap: len=%d > MaxResultLength=%d", len(body), MaxResultLength)
+	}
+	// And the discovery advice must be appended.
+	if !strings.HasSuffix(tc.Text, discoveryAdvice) {
+		t.Errorf("expected discoveryAdvice suffix; tail=%q", tc.Text[max(0, len(tc.Text)-120):])
+	}
+}

--- a/internal/tools/prometheus/tools_test.go
+++ b/internal/tools/prometheus/tools_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -45,9 +46,9 @@ func TestRegisterPrometheusTools(t *testing.T) {
 func TestRegisterPrometheusToolsWithMiddleware(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == apiQueryPath {
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"status": "success",
-				"data":   map[string]interface{}{"resultType": "vector", "result": []interface{}{}},
+				"data":   map[string]any{"resultType": "vector", "result": []any{}},
 			})
 		} else {
 			w.WriteHeader(http.StatusNotFound)
@@ -200,11 +201,11 @@ func TestHandleExecuteQuery(t *testing.T) {
 	// Create mock server
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == apiQueryPath {
-			response := map[string]interface{}{
+			response := map[string]any{
 				"status": "success",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"resultType": "vector",
-					"result":     []interface{}{},
+					"result":     []any{},
 				},
 			}
 			_ = json.NewEncoder(w).Encode(response)
@@ -236,7 +237,7 @@ func TestHandleExecuteQuery(t *testing.T) {
 	request := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "execute_query",
-			Arguments: map[string]interface{}{
+			Arguments: map[string]any{
 				"query": "up",
 			},
 		},
@@ -255,7 +256,7 @@ func TestHandleExecuteQuery(t *testing.T) {
 	requestBad := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name:      "execute_query",
-			Arguments: map[string]interface{}{},
+			Arguments: map[string]any{},
 		},
 	}
 
@@ -273,11 +274,11 @@ func TestHandleExecuteRangeQuery(t *testing.T) {
 	// Create mock server
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v1/query_range" {
-			response := map[string]interface{}{
+			response := map[string]any{
 				"status": "success",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"resultType": "matrix",
-					"result":     []interface{}{},
+					"result":     []any{},
 				},
 			}
 			_ = json.NewEncoder(w).Encode(response)
@@ -309,7 +310,7 @@ func TestHandleExecuteRangeQuery(t *testing.T) {
 	request := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "execute_range_query",
-			Arguments: map[string]interface{}{
+			Arguments: map[string]any{
 				"query": "up",
 				"start": "2023-01-01T00:00:00Z",
 				"end":   "2023-01-01T01:00:00Z",
@@ -332,11 +333,11 @@ func TestHandleGetMetricMetadata(t *testing.T) {
 	// Create mock server
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v1/metadata" {
-			response := map[string]interface{}{
+			response := map[string]any{
 				"status": "success",
-				"data": map[string]interface{}{
-					"http_requests_total": []interface{}{
-						map[string]interface{}{
+				"data": map[string]any{
+					"http_requests_total": []any{
+						map[string]any{
 							"type": "counter",
 							"help": "Total HTTP requests",
 							"unit": "",
@@ -373,7 +374,7 @@ func TestHandleGetMetricMetadata(t *testing.T) {
 	request := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "get_metric_metadata",
-			Arguments: map[string]interface{}{
+			Arguments: map[string]any{
 				"metric": "http_requests_total",
 			},
 		},
@@ -607,7 +608,7 @@ func TestHandleListLabelNamesTruncation(t *testing.T) {
 			names[i] = fmt.Sprintf("label_%05d", i)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"status": "success",
 			"data":   names,
 		})
@@ -630,7 +631,7 @@ func TestHandleListLabelNamesTruncation(t *testing.T) {
 	}
 
 	// Exercise the production path: handler wrapped by truncationMiddleware.
-	h := truncationMiddleware("list_label_names", func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	h := truncationMiddleware("list_label_names", discoveryAdvice, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleListLabelNames(ctx, req, client, sc)
 	})
 
@@ -673,57 +674,142 @@ func TestTruncationMiddleware(t *testing.T) {
 		}
 	}
 
-	t.Run("truncates oversized output and appends the tool's advice", func(t *testing.T) {
-		h := truncationMiddleware("find_series", makeHandler(bigText))
+	tests := []struct {
+		name       string
+		toolName   string
+		advice     string
+		text       string
+		unlimited  bool
+		wantSuffix string // empty: expect text returned verbatim
+	}{
+		{
+			name:       "discovery tool truncates with discoveryAdvice",
+			toolName:   "find_series",
+			advice:     discoveryAdvice,
+			text:       bigText,
+			wantSuffix: discoveryAdvice,
+		},
+		{
+			name:       "bulk tool truncates with bulkAdvice",
+			toolName:   "get_rules",
+			advice:     bulkAdvice,
+			text:       bigText,
+			wantSuffix: bulkAdvice,
+		},
+		{
+			name:       "alerts tool truncates with alertsAdvice",
+			toolName:   "get_alerts",
+			advice:     alertsAdvice,
+			text:       bigText,
+			wantSuffix: alertsAdvice,
+		},
+		{
+			name:       "query tool truncates with TruncationAdvice",
+			toolName:   "execute_query",
+			advice:     TruncationAdvice,
+			text:       bigText,
+			wantSuffix: TruncationAdvice,
+		},
+		{
+			name:       "short text passes through untouched",
+			toolName:   "execute_query",
+			advice:     TruncationAdvice,
+			text:       smallText,
+			wantSuffix: "",
+		},
+		{
+			name:       "unlimited=true bypasses on query tool",
+			toolName:   "execute_query",
+			advice:     TruncationAdvice,
+			text:       bigText,
+			unlimited:  true,
+			wantSuffix: "",
+		},
+		{
+			name:       "unlimited=true bypasses on range query tool",
+			toolName:   "execute_range_query",
+			advice:     TruncationAdvice,
+			text:       bigText,
+			unlimited:  true,
+			wantSuffix: "",
+		},
+		{
+			name:       "unlimited=true is ignored on bulk tool",
+			toolName:   "get_rules",
+			advice:     bulkAdvice,
+			text:       bigText,
+			unlimited:  true,
+			wantSuffix: bulkAdvice,
+		},
+		{
+			name:       "unlimited=true is ignored on discovery tool",
+			toolName:   "find_series",
+			advice:     discoveryAdvice,
+			text:       bigText,
+			unlimited:  true,
+			wantSuffix: discoveryAdvice,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := truncationMiddleware(tt.toolName, tt.advice, makeHandler(tt.text))
+			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Name: tt.toolName}}
+			if tt.unlimited {
+				req.Params.Arguments = map[string]any{"unlimited": "true"}
+			}
+			res, err := h(context.Background(), req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got := res.Content[0].(mcp.TextContent).Text
+
+			if tt.wantSuffix == "" {
+				if got != tt.text {
+					t.Errorf("expected passthrough; len got=%d want=%d", len(got), len(tt.text))
+				}
+				return
+			}
+			if !strings.HasSuffix(got, tt.wantSuffix) {
+				t.Errorf("expected suffix %q; tail=%q", strings.TrimSpace(tt.wantSuffix)[:20], got[max(0, len(got)-120):])
+			}
+			if len(got) > MaxResultLength+len(tt.wantSuffix) {
+				t.Errorf("truncated text longer than cap+advice: %d", len(got))
+			}
+		})
+	}
+
+	t.Run("truncates every oversized TextContent in a multi-block result", func(t *testing.T) {
+		h := truncationMiddleware("find_series", discoveryAdvice, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					mcp.TextContent{Type: "text", Text: bigText},
+					mcp.TextContent{Type: "text", Text: smallText},
+					mcp.TextContent{Type: "text", Text: bigText},
+				},
+			}, nil
+		})
 		res, err := h(context.Background(), mcp.CallToolRequest{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		got := res.Content[0].(mcp.TextContent).Text
-		if !strings.HasSuffix(got, discoveryAdvice) {
-			t.Errorf("expected discoveryAdvice suffix for find_series")
+		first := res.Content[0].(mcp.TextContent).Text
+		middle := res.Content[1].(mcp.TextContent).Text
+		last := res.Content[2].(mcp.TextContent).Text
+		if !strings.HasSuffix(first, discoveryAdvice) {
+			t.Error("expected first block to be truncated")
 		}
-		if len(got) > MaxResultLength+len(discoveryAdvice) {
-			t.Errorf("truncated text longer than expected: %d", len(got))
+		if middle != smallText {
+			t.Errorf("expected middle block untouched, got %q", middle)
 		}
-	})
-
-	t.Run("unmapped tool falls back to bulkAdvice", func(t *testing.T) {
-		h := truncationMiddleware("not_a_real_tool", makeHandler(bigText))
-		res, _ := h(context.Background(), mcp.CallToolRequest{})
-		got := res.Content[0].(mcp.TextContent).Text
-		if !strings.HasSuffix(got, bulkAdvice) {
-			t.Errorf("expected bulkAdvice fallback for unmapped tool")
-		}
-	})
-
-	t.Run("short text passes through untouched", func(t *testing.T) {
-		h := truncationMiddleware("execute_query", makeHandler(smallText))
-		res, _ := h(context.Background(), mcp.CallToolRequest{})
-		got := res.Content[0].(mcp.TextContent).Text
-		if got != smallText {
-			t.Errorf("expected passthrough %q, got %q", smallText, got)
-		}
-	})
-
-	t.Run("unlimited=true bypasses truncation", func(t *testing.T) {
-		h := truncationMiddleware("execute_query", makeHandler(bigText))
-		req := mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Name:      "execute_query",
-				Arguments: map[string]interface{}{"unlimited": "true"},
-			},
-		}
-		res, _ := h(context.Background(), req)
-		got := res.Content[0].(mcp.TextContent).Text
-		if got != bigText {
-			t.Errorf("expected raw bigText with unlimited=true; len got=%d, want=%d", len(got), len(bigText))
+		if !strings.HasSuffix(last, discoveryAdvice) {
+			t.Error("expected last block to be truncated")
 		}
 	})
 
 	t.Run("propagates handler errors without modification", func(t *testing.T) {
 		boom := fmt.Errorf("boom")
-		h := truncationMiddleware("execute_query", func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		h := truncationMiddleware("execute_query", TruncationAdvice, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return nil, boom
 		})
 		_, err := h(context.Background(), mcp.CallToolRequest{})
@@ -733,7 +819,7 @@ func TestTruncationMiddleware(t *testing.T) {
 	})
 
 	t.Run("preserves IsError flag on tool error results", func(t *testing.T) {
-		h := truncationMiddleware("execute_query", func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		h := truncationMiddleware("execute_query", TruncationAdvice, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return &mcp.CallToolResult{
 				IsError: true,
 				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: bigText}},
@@ -746,6 +832,31 @@ func TestTruncationMiddleware(t *testing.T) {
 		got := res.Content[0].(mcp.TextContent).Text
 		if !strings.HasSuffix(got, TruncationAdvice) {
 			t.Error("expected truncation to still apply to error results")
+		}
+	})
+}
+
+// TestTruncateWithAdviceUTF8 verifies that truncation never lands mid-rune,
+// so the resulting string remains valid UTF-8 even when the byte cap falls
+// inside a multi-byte character.
+func TestTruncateWithAdviceUTF8(t *testing.T) {
+	const advice = "ADV"
+
+	t.Run("backs off mid-rune cut to a valid boundary", func(t *testing.T) {
+		// Build a payload where MaxResultLength sits inside a 4-byte rune
+		// (U+1F4A1 LIGHT BULB = 0xF0 0x9F 0x92 0xA1). No newlines, so the
+		// newline-anchor branch doesn't apply.
+		const bulb = "\U0001F4A1"
+		// Pad so a bulb crosses the MaxResultLength boundary.
+		padLen := MaxResultLength - 2
+		in := strings.Repeat("a", padLen) + bulb + strings.Repeat("b", 100)
+		got := truncateWithAdvice(in, advice)
+		body := strings.TrimSuffix(got, advice)
+		if !utf8.ValidString(body) {
+			t.Errorf("truncated body is not valid UTF-8: %q", body[len(body)-8:])
+		}
+		if !strings.HasSuffix(got, advice) {
+			t.Error("expected advice suffix")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Extends the existing 50,000-char output cap (previously only on `execute_query` / `execute_range_query`) to 11 other read-only tools whose `%+v`-formatted responses could return megabytes from a real Mimir tenant.
- Extracts a small `truncateWithAdvice` helper out of `formatQueryResult` so the cap, the newline-alignment behaviour, and the user-facing advice live in one place.
- Adds two advice variants tuned to the tool family — `discoveryAdvice` (suggests tighter `matches` / time window / `limit`) for label/series/metadata/exemplar tools, and `bulkAdvice` (points at narrower tools instead) for the system-dump tools that have no filter parameters.

Coverage:

| Family | Handlers |
|---|---|
| Discovery (`discoveryAdvice`) | `get_metric_metadata`, `list_label_names`, `list_label_values`, `find_series`, `query_exemplars`, `get_targets_metadata` |
| Bulk system dump (`bulkAdvice`) | `get_targets`, `get_rules`, `get_alerts`, `get_config`, `get_tsdb_stats` |

`get_build_info`, `get_runtime_info`, `get_flags`, `get_alertmanagers`, and `check_ready` are intentionally untouched — bounded by nature. The existing display caps in `find_series` (50 entries) and `list_label_values` (100 entries) stay as a first-pass trim; the new byte cap is a safety net behind them. No new tool parameters: the `unlimited` escape hatch remains exclusive to the query tools.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `TestTruncateWithAdvice` — passthrough, hard-byte cut, newline-aligned cut
- [x] `TestHandleListLabelNamesTruncation` — handler-level test; httptest stub returns 6,000 label names, asserts the rendered body stays ≤ `MaxResultLength` and `discoveryAdvice` is appended
- [x] Manual smoke against a real Mimir gateway (call `get_rules` and confirm advice appears for a large tenant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)