### PR TITLE
Enable JSON-Schema input validation for all tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added MCP tool annotations (`readOnlyHint`, `openWorldHint`) to all tools to help clients and users assess tool behavior ([#36355](https://github.com/giantswarm/giantswarm/issues/36355)).
+- Enable JSON-Schema input validation for every tool (per [SEP-1303](https://modelcontextprotocol.io/seps/1303-input-validation-errors-as-tool-execution-errors)). Calls with unknown property names, wrong types, or missing required fields now return a structured tool execution error instead of being silently dropped, so the model can self-correct ([#36458](https://github.com/giantswarm/giantswarm/issues/36458)).
 
 ## [0.1.0] - 2026-03-30
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -230,6 +230,7 @@ func runServe(transport string, debugMode bool, enableOAuth bool,
 	// Create MCP server
 	mcpSrv := mcpserver.NewMCPServer("mcp-prometheus", rootCmd.Version,
 		mcpserver.WithToolCapabilities(true),
+		mcpserver.WithInputSchemaValidation(),
 	)
 
 	// Register Prometheus tools with observability instrumentation

--- a/internal/tools/prometheus/input_validation_test.go
+++ b/internal/tools/prometheus/input_validation_test.go
@@ -1,0 +1,148 @@
+package prometheus
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"github.com/giantswarm/mcp-prometheus/internal/server"
+)
+
+// TestInputSchemaValidation_RejectsUnknownProperty pins the motivating
+// scenario from giantswarm/giantswarm#36458: a caller that sends a typo'd or
+// stale property to a tool must receive a structured tool execution error
+// that names the offending property, so the model can self-correct.
+//
+// This is an end-to-end check that:
+//  1. WithInputSchemaValidation is wired into the server in cmd/serve.go, and
+//  2. WithSchemaAdditionalProperties(false) is set in registerPrometheusTools
+//     so unknown properties are rejected for every registered tool.
+func TestInputSchemaValidation_RejectsUnknownProperty(t *testing.T) {
+	srv, _, cleanup := newValidatingServer(t)
+	defer cleanup()
+
+	resp := dispatchToolCall(t, srv, "execute_query", map[string]any{
+		"quary": "up", // intentional typo of "query"
+	})
+
+	jr, ok := resp.(mcp.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("expected JSON-RPC response, got %T", resp)
+	}
+	result, ok := jr.Result.(*mcp.CallToolResult)
+	if !ok {
+		t.Fatalf("expected *mcp.CallToolResult, got %T", jr.Result)
+	}
+	if !result.IsError {
+		t.Fatal("expected validation to mark result as error")
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected error content, got none")
+	}
+	tc, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	if !strings.Contains(tc.Text, "quary") {
+		t.Fatalf("validation error should mention the offending property; got: %s", tc.Text)
+	}
+}
+
+// TestInputSchemaValidation_AcceptsKnownProperty makes sure a well-formed call
+// passes validation and reaches the handler, so the rejection test above is
+// meaningful (i.e. it isn't a side effect of an unrelated server-level reject).
+func TestInputSchemaValidation_AcceptsKnownProperty(t *testing.T) {
+	srv, mockURL, cleanup := newValidatingServer(t)
+	defer cleanup()
+
+	resp := dispatchToolCall(t, srv, "execute_query", map[string]any{
+		"query":          "up",
+		"prometheus_url": mockURL,
+	})
+
+	jr, ok := resp.(mcp.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("expected JSON-RPC response, got %T", resp)
+	}
+	result, ok := jr.Result.(*mcp.CallToolResult)
+	if !ok {
+		t.Fatalf("expected *mcp.CallToolResult, got %T", jr.Result)
+	}
+	if result.IsError {
+		text := ""
+		if len(result.Content) > 0 {
+			if tc, ok := result.Content[0].(mcp.TextContent); ok {
+				text = tc.Text
+			}
+		}
+		t.Fatalf("well-formed call should not be rejected; got error: %s", text)
+	}
+}
+
+// newValidatingServer spins up an MCP server with input schema validation
+// enabled (matching cmd/serve.go) and registers all Prometheus tools against
+// a mock Prometheus endpoint. Returns the server, the mock URL, and a cleanup
+// function the caller must defer.
+func newValidatingServer(t *testing.T) (*mcpserver.MCPServer, string, func()) {
+	t.Helper()
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == apiQueryPath {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data":   map[string]any{"resultType": "vector", "result": []any{}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	sc, err := server.NewServerContext(context.Background(),
+		server.WithPrometheusConfig(server.PrometheusConfig{URL: mockServer.URL}),
+		server.WithSlogLogger(discardLogger()),
+	)
+	if err != nil {
+		mockServer.Close()
+		t.Fatalf("Failed to create server context: %v", err)
+	}
+
+	srv := mcpserver.NewMCPServer("test", "0.0.0",
+		mcpserver.WithToolCapabilities(true),
+		mcpserver.WithInputSchemaValidation(),
+	)
+	if err := RegisterPrometheusTools(srv, sc); err != nil {
+		_ = sc.Shutdown()
+		mockServer.Close()
+		t.Fatalf("RegisterPrometheusTools: %v", err)
+	}
+
+	cleanup := func() {
+		_ = sc.Shutdown()
+		mockServer.Close()
+	}
+	return srv, mockServer.URL, cleanup
+}
+
+func dispatchToolCall(t *testing.T, srv *mcpserver.MCPServer, toolName string, args map[string]any) mcp.JSONRPCMessage {
+	t.Helper()
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      toolName,
+			"arguments": args,
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return srv.HandleMessage(context.Background(), raw)
+}

--- a/internal/tools/prometheus/input_validation_test.go
+++ b/internal/tools/prometheus/input_validation_test.go
@@ -54,6 +54,27 @@ func TestInputSchemaValidation_RejectsUnknownProperty(t *testing.T) {
 	}
 }
 
+// TestInputSchemaValidation_AllToolsRejectAdditional locks in the invariant
+// that every registered tool's input schema has additionalProperties: false.
+// Without this, a future tool author who registers a tool outside the shared
+// registerPrometheusTools helper would silently lose strict validation.
+func TestInputSchemaValidation_AllToolsRejectAdditional(t *testing.T) {
+	srv, _, cleanup := newValidatingServer(t)
+	defer cleanup()
+
+	tools := srv.ListTools()
+	if len(tools) == 0 {
+		t.Fatal("expected registered tools, got none")
+	}
+	for name, st := range tools {
+		ap := st.Tool.InputSchema.AdditionalProperties
+		b, ok := ap.(bool)
+		if !ok || b {
+			t.Errorf("tool %q: additionalProperties must be false, got %#v", name, ap)
+		}
+	}
+}
+
 // TestInputSchemaValidation_AcceptsKnownProperty makes sure a well-formed call
 // passes validation and reaches the handler, so the rejection test above is
 // meaningful (i.e. it isn't a side effect of an unrelated server-level reject).

--- a/internal/tools/prometheus/tools.go
+++ b/internal/tools/prometheus/tools.go
@@ -236,10 +236,8 @@ func registerPrometheusTools(s *mcpserver.MCPServer, client *Client, sc *server.
 		mcp.WithDescription(description),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
-		// Reject unknown property names so callers can't pass typo'd or stale
-		// arguments silently. Combined with WithInputSchemaValidation() at the
-		// server level, this turns SEP-1303 input errors into structured
-		// tool-execution errors the model can self-correct from.
+		// Combined with WithInputSchemaValidation() (server-level), this rejects
+		// unknown property names so typo'd args surface as errors — SEP-1303.
 		mcp.WithSchemaAdditionalProperties(false),
 	}
 	tool := mcp.NewTool(toolName, append(baseOptions, allOptions...)...)

--- a/internal/tools/prometheus/tools.go
+++ b/internal/tools/prometheus/tools.go
@@ -236,6 +236,11 @@ func registerPrometheusTools(s *mcpserver.MCPServer, client *Client, sc *server.
 		mcp.WithDescription(description),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
+		// Reject unknown property names so callers can't pass typo'd or stale
+		// arguments silently. Combined with WithInputSchemaValidation() at the
+		// server level, this turns SEP-1303 input errors into structured
+		// tool-execution errors the model can self-correct from.
+		mcp.WithSchemaAdditionalProperties(false),
 	}
 	tool := mcp.NewTool(toolName, append(baseOptions, allOptions...)...)
 


### PR DESCRIPTION
## Summary

- Activates [mcp-go's `WithInputSchemaValidation()`](https://github.com/mark3labs/mcp-go/pull/834) server option (opt-in per [SEP-1303](https://modelcontextprotocol.io/seps/1303-input-validation-errors-as-tool-execution-errors), available since mcp-go v0.52.0).
- Sets `additionalProperties: false` on every registered tool's input schema via the shared `registerPrometheusTools` helper. Calls with unknown property names, wrong types, or missing required fields now return a structured tool execution error so the model can self-correct, instead of being silently dropped.
- Adds end-to-end tests pinning both the rejection (unknown property) and acceptance (known property) paths against `execute_query`, plus an invariant test that walks `srv.ListTools()` and asserts every registered tool's schema has `additionalProperties: false` — locks in strictness for future tools.

## Why opt-in needs both levers

`WithInputSchemaValidation()` alone enforces required fields, types, and enums but **does not reject unknown property names** unless the schema also sets `additionalProperties: false`. Both levers are applied here so a typo'd or stale argument from the model surfaces as a structured error instead of being silently dropped.

Unlike [giantswarm/mcp-kubernetes#394](https://github.com/giantswarm/mcp-kubernetes/pull/394), every tool here flows through one shared registration helper (`registerPrometheusTools`), so `additionalProperties: false` is applied once in `baseOptions` and covers all 18 tools — strict-by-default for any future tool registered through the helper.

## Audit performed

Cross-checked every handler's argument reads against its tool schema for all 18 in-scope tools. Audit was clean — every key every handler reads is declared, no deprecated aliases, no `podName`-style backward-compat fallback. The `unlimited` parameter is correctly scoped: it's in the schema only for `execute_query` and `execute_range_query` (via `withQueryEnhancementParams`), which matches `allowsUnlimited` in `truncationMiddleware`.

Refs [giantswarm/giantswarm#36458](https://github.com/giantswarm/giantswarm/issues/36458).