### PR TITLE
ci: fix goconst lint violations

### DIFF
--- a/internal/oauth/setup.go
+++ b/internal/oauth/setup.go
@@ -85,6 +85,9 @@ type Config struct {
 // envTrue is the string value that enables a boolean env var.
 const envTrue = "true"
 
+// storageTypeValkey selects the Valkey-backed token store via OAUTH_STORAGE.
+const storageTypeValkey = "valkey"
+
 // ConfigFromEnv builds a Config by reading the standard environment variables.
 func ConfigFromEnv() Config {
 	cfg := Config{
@@ -203,7 +206,7 @@ type combinedStore interface {
 
 // newStore creates the token storage backend based on cfg.StorageType.
 func newStore(_ context.Context, cfg Config, _ *slog.Logger) (combinedStore, func(), error) {
-	if cfg.StorageType == "valkey" {
+	if cfg.StorageType == storageTypeValkey {
 		return newValkeyStore(cfg)
 	}
 	// Default: in-process memory store (dev / single-replica).

--- a/internal/oauth/setup_test.go
+++ b/internal/oauth/setup_test.go
@@ -8,6 +8,12 @@ import (
 	"github.com/giantswarm/mcp-oauth/providers/mock"
 )
 
+const (
+	testSecret    = "secret"
+	testDexIssuer = "https://dex.example.com"
+	testMCPIssuer = "https://mcp.example.com"
+)
+
 func TestConfigFromEnvDefaults(t *testing.T) {
 	// Clear any OAuth env vars to test defaults. ConfigFromEnv uses os.Getenv,
 	// which returns "" whether the var is unset or empty, so t.Setenv(key, "")
@@ -43,12 +49,12 @@ func TestConfigFromEnvReadsValues(t *testing.T) {
 	t.Setenv("MCP_OAUTH_ISSUER", "https://issuer.example.com")
 	t.Setenv("MCP_OAUTH_ENCRYPTION_KEY", "deadbeef")
 	t.Setenv("MCP_OAUTH_ALLOW_PUBLIC_REGISTRATION", "true")
-	t.Setenv("OAUTH_STORAGE", "valkey")
+	t.Setenv("OAUTH_STORAGE", storageTypeValkey)
 	t.Setenv("VALKEY_URL", "valkey://localhost:6379")
-	t.Setenv("VALKEY_PASSWORD", "secret")
+	t.Setenv("VALKEY_PASSWORD", testSecret)
 	t.Setenv("VALKEY_TLS_ENABLED", "true")
 	t.Setenv("VALKEY_KEY_PREFIX", "myapp:")
-	t.Setenv("DEX_ISSUER_URL", "https://dex.example.com")
+	t.Setenv("DEX_ISSUER_URL", testDexIssuer)
 	t.Setenv("DEX_CLIENT_ID", "mcp-prometheus")
 	t.Setenv("DEX_CLIENT_SECRET", "dexsecret")
 	t.Setenv("DEX_REDIRECT_URL", "https://app.example.com/oauth/callback")
@@ -62,11 +68,11 @@ func TestConfigFromEnvReadsValues(t *testing.T) {
 	}{
 		{"Issuer", cfg.Issuer, "https://issuer.example.com"},
 		{"EncryptionKey", cfg.EncryptionKey, "deadbeef"},
-		{"StorageType", cfg.StorageType, "valkey"},
+		{"StorageType", cfg.StorageType, storageTypeValkey},
 		{"ValkeyURL", cfg.ValkeyURL, "valkey://localhost:6379"},
-		{"ValkeyPassword", cfg.ValkeyPassword, "secret"},
+		{"ValkeyPassword", cfg.ValkeyPassword, testSecret},
 		{"ValkeyKeyPrefix", cfg.ValkeyKeyPrefix, "myapp:"},
-		{"DexIssuerURL", cfg.DexIssuerURL, "https://dex.example.com"},
+		{"DexIssuerURL", cfg.DexIssuerURL, testDexIssuer},
 		{"DexClientID", cfg.DexClientID, "mcp-prometheus"},
 		{"DexClientSecret", cfg.DexClientSecret, "dexsecret"},
 		{"DexRedirectURL", cfg.DexRedirectURL, "https://app.example.com/oauth/callback"},
@@ -97,9 +103,9 @@ func TestConfigFromEnvAllowPrivateURLs(t *testing.T) {
 
 func TestNewHandlerMissingIssuer(t *testing.T) {
 	cfg := Config{
-		DexIssuerURL:    "https://dex.example.com",
+		DexIssuerURL:    testDexIssuer,
 		DexClientID:     "id",
-		DexClientSecret: "secret",
+		DexClientSecret: testSecret,
 		DexRedirectURL:  "https://app.example.com/callback",
 	}
 	_, _, err := NewHandler(context.Background(), cfg, slog.Default())
@@ -110,9 +116,9 @@ func TestNewHandlerMissingIssuer(t *testing.T) {
 
 func TestNewHandlerMissingDexIssuer(t *testing.T) {
 	cfg := Config{
-		Issuer:          "https://mcp.example.com",
+		Issuer:          testMCPIssuer,
 		DexClientID:     "id",
-		DexClientSecret: "secret",
+		DexClientSecret: testSecret,
 		DexRedirectURL:  "https://app.example.com/callback",
 	}
 	_, _, err := NewHandler(context.Background(), cfg, slog.Default())
@@ -123,10 +129,10 @@ func TestNewHandlerMissingDexIssuer(t *testing.T) {
 
 func TestNewHandlerMissingRedirectURL(t *testing.T) {
 	cfg := Config{
-		Issuer:          "https://mcp.example.com",
-		DexIssuerURL:    "https://dex.example.com",
+		Issuer:          testMCPIssuer,
+		DexIssuerURL:    testDexIssuer,
 		DexClientID:     "id",
-		DexClientSecret: "secret",
+		DexClientSecret: testSecret,
 		// DexRedirectURL intentionally missing
 	}
 	_, _, err := NewHandler(context.Background(), cfg, slog.Default())
@@ -152,7 +158,7 @@ func TestNewStoreMemory(t *testing.T) {
 }
 
 func TestNewStoreValkeyMissingURL(t *testing.T) {
-	_, _, err := newStore(context.Background(), Config{StorageType: "valkey", ValkeyURL: ""}, slog.Default())
+	_, _, err := newStore(context.Background(), Config{StorageType: storageTypeValkey, ValkeyURL: ""}, slog.Default())
 	if err == nil {
 		t.Error("expected error when VALKEY_URL is empty with valkey storage type")
 	}
@@ -193,7 +199,7 @@ func TestNewValkeyStoreKeyPrefixBranch(t *testing.T) {
 func TestNewHandlerWithProviderMemoryStore(t *testing.T) {
 	p := mock.NewProvider()
 	cfg := Config{
-		Issuer:                  "https://mcp.example.com",
+		Issuer:                  testMCPIssuer,
 		AllowPublicRegistration: true,
 	}
 	h, cleanup, err := newHandlerWithProvider(context.Background(), p, cfg, slog.Default())
@@ -211,7 +217,7 @@ func TestNewHandlerWithProviderShortEncryptionKey(t *testing.T) {
 	// security.NewEncryptor (AES-256 requires exactly 32 bytes).
 	p := mock.NewProvider()
 	cfg := Config{
-		Issuer:        "https://mcp.example.com",
+		Issuer:        testMCPIssuer,
 		EncryptionKey: "0102030405", // 5 bytes, not 32
 	}
 	_, _, err := newHandlerWithProvider(context.Background(), p, cfg, slog.Default())

--- a/internal/server/context_test.go
+++ b/internal/server/context_test.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 )
 
+const tenantA = "tenant-a"
+
 // stubResolver implements TenancyResolver for testing.
 type stubResolver struct{}
 
 func (s *stubResolver) TenantsForGroups(_ context.Context, _ []string) ([]string, error) {
-	return []string{"tenant-a"}, nil
+	return []string{tenantA}, nil
 }
 
 func TestWithOAuthEnabled(t *testing.T) {
@@ -111,7 +113,7 @@ func TestContextNotNil(t *testing.T) {
 }
 
 func TestPrometheusConfigOption(t *testing.T) {
-	cfg := PrometheusConfig{URL: "http://prom:9090", OrgID: "tenant-a"}
+	cfg := PrometheusConfig{URL: "http://prom:9090", OrgID: tenantA}
 	sc, err := NewServerContext(context.Background(), WithPrometheusConfig(cfg))
 	if err != nil {
 		t.Fatal(err)
@@ -120,7 +122,7 @@ func TestPrometheusConfigOption(t *testing.T) {
 	if got.URL != "http://prom:9090" {
 		t.Errorf("unexpected URL: %s", got.URL)
 	}
-	if got.OrgID != "tenant-a" {
+	if got.OrgID != tenantA {
 		t.Errorf("unexpected OrgID: %s", got.OrgID)
 	}
 }

--- a/internal/tenancy/mode_test.go
+++ b/internal/tenancy/mode_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestNewResolverForMode_Static_AllUsers(t *testing.T) {
-	r, err := NewResolverForMode(ModeStatic, []string{"prod-eu"}, nil)
+	r, err := NewResolverForMode(ModeStatic, []string{tenantProdEU}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -15,7 +15,7 @@ func TestNewResolverForMode_Static_AllUsers(t *testing.T) {
 }
 
 func TestNewResolverForMode_Static_GroupMap(t *testing.T) {
-	r, err := NewResolverForMode(ModeStatic, nil, map[string][]string{"team-ops": {"prod-eu"}})
+	r, err := NewResolverForMode(ModeStatic, nil, map[string][]string{groupTeamOps: {tenantProdEU}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/tenancy/static_test.go
+++ b/internal/tenancy/static_test.go
@@ -7,16 +7,20 @@ import (
 
 const (
 	tenantProdEU    = "prod-eu"
+	tenantProdUS    = "prod-us"
+	tenantStaging   = "staging"
+	groupTeamOps    = "team-ops"
+	groupTeamDev    = "team-dev"
 	overwrittenMark = "OVERWRITTEN"
 )
 
 func TestStaticResolver_AllUsersMode_ReturnsFixedList(t *testing.T) {
-	r := NewStaticResolver([]string{tenantProdEU, "staging"}, nil)
+	r := NewStaticResolver([]string{tenantProdEU, tenantStaging}, nil)
 	tenants, err := r.TenantsForGroups(context.Background(), []string{"any-group"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(tenants) != 2 || tenants[0] != tenantProdEU || tenants[1] != "staging" {
+	if len(tenants) != 2 || tenants[0] != tenantProdEU || tenants[1] != tenantStaging {
 		t.Errorf("got %v, want [prod-eu staging]", tenants)
 	}
 }
@@ -34,7 +38,7 @@ func TestStaticResolver_AllUsersMode_NilGroups(t *testing.T) {
 
 func TestStaticResolver_AllUsersMode_EmptyGroupMap(t *testing.T) {
 	r := NewStaticResolver([]string{tenantProdEU}, map[string][]string{})
-	tenants, err := r.TenantsForGroups(context.Background(), []string{"team-ops"})
+	tenants, err := r.TenantsForGroups(context.Background(), []string{groupTeamOps})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -44,7 +48,7 @@ func TestStaticResolver_AllUsersMode_EmptyGroupMap(t *testing.T) {
 }
 
 func TestStaticResolver_AllUsersMode_MutationIsolation(t *testing.T) {
-	input := []string{tenantProdEU, "staging"}
+	input := []string{tenantProdEU, tenantStaging}
 	r := NewStaticResolver(input, nil)
 
 	// Mutate the input slice after construction.
@@ -71,29 +75,29 @@ func TestStaticResolver_AllUsersMode_ReturnCopyIsolation(t *testing.T) {
 
 func TestStaticResolver_GroupMapping_SingleMatch(t *testing.T) {
 	r := NewStaticResolver(nil, map[string][]string{
-		"team-ops": {tenantProdEU, "prod-us"},
-		"team-dev": {"staging"},
+		groupTeamOps: {tenantProdEU, tenantProdUS},
+		groupTeamDev: {tenantStaging},
 	})
-	tenants, err := r.TenantsForGroups(context.Background(), []string{"team-ops"})
+	tenants, err := r.TenantsForGroups(context.Background(), []string{groupTeamOps})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(tenants) != 2 || tenants[0] != tenantProdEU || tenants[1] != "prod-us" {
+	if len(tenants) != 2 || tenants[0] != tenantProdEU || tenants[1] != tenantProdUS {
 		t.Errorf("got %v, want [prod-eu prod-us]", tenants)
 	}
 }
 
 func TestStaticResolver_GroupMapping_MultipleGroups_UnionAndDedup(t *testing.T) {
 	r := NewStaticResolver(nil, map[string][]string{
-		"team-ops": {tenantProdEU, "prod-us"},
-		"team-dev": {tenantProdEU, "staging"}, // prod-eu shared
+		groupTeamOps: {tenantProdEU, tenantProdUS},
+		groupTeamDev: {tenantProdEU, tenantStaging}, // prod-eu shared
 	})
-	tenants, err := r.TenantsForGroups(context.Background(), []string{"team-ops", "team-dev"})
+	tenants, err := r.TenantsForGroups(context.Background(), []string{groupTeamOps, groupTeamDev})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// Expect sorted, deduplicated union.
-	want := []string{tenantProdEU, "prod-us", "staging"}
+	want := []string{tenantProdEU, tenantProdUS, tenantStaging}
 	if len(tenants) != len(want) {
 		t.Fatalf("got %v, want %v", tenants, want)
 	}
@@ -106,7 +110,7 @@ func TestStaticResolver_GroupMapping_MultipleGroups_UnionAndDedup(t *testing.T) 
 
 func TestStaticResolver_GroupMapping_NoMatch(t *testing.T) {
 	r := NewStaticResolver(nil, map[string][]string{
-		"team-ops": {tenantProdEU},
+		groupTeamOps: {tenantProdEU},
 	})
 	tenants, err := r.TenantsForGroups(context.Background(), []string{"team-unknown"})
 	if err != nil {
@@ -119,7 +123,7 @@ func TestStaticResolver_GroupMapping_NoMatch(t *testing.T) {
 
 func TestStaticResolver_GroupMapping_NilGroups(t *testing.T) {
 	r := NewStaticResolver(nil, map[string][]string{
-		"team-ops": {tenantProdEU},
+		groupTeamOps: {tenantProdEU},
 	})
 	tenants, err := r.TenantsForGroups(context.Background(), nil)
 	if err != nil {
@@ -133,9 +137,9 @@ func TestStaticResolver_GroupMapping_NilGroups(t *testing.T) {
 func TestStaticResolver_GroupMapping_TakesPrecedenceOverAllTenants(t *testing.T) {
 	// When groupMap is non-empty, allTenants must be ignored.
 	r := NewStaticResolver([]string{"should-be-ignored"}, map[string][]string{
-		"team-ops": {tenantProdEU},
+		groupTeamOps: {tenantProdEU},
 	})
-	tenants, err := r.TenantsForGroups(context.Background(), []string{"team-ops"})
+	tenants, err := r.TenantsForGroups(context.Background(), []string{groupTeamOps})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -146,15 +150,15 @@ func TestStaticResolver_GroupMapping_TakesPrecedenceOverAllTenants(t *testing.T)
 
 func TestStaticResolver_GroupMapping_MutationIsolation(t *testing.T) {
 	groupMap := map[string][]string{
-		"team-ops": {tenantProdEU},
+		groupTeamOps: {tenantProdEU},
 	}
 	r := NewStaticResolver(nil, groupMap)
 
 	// Mutate the map and its values after construction.
-	groupMap["team-ops"][0] = overwrittenMark
-	groupMap["team-new"] = []string{"staging"}
+	groupMap[groupTeamOps][0] = overwrittenMark
+	groupMap["team-new"] = []string{tenantStaging}
 
-	tenants, _ := r.TenantsForGroups(context.Background(), []string{"team-ops"})
+	tenants, _ := r.TenantsForGroups(context.Background(), []string{groupTeamOps})
 	if len(tenants) != 1 || tenants[0] != tenantProdEU {
 		t.Errorf("resolver was affected by external mutation: got %v", tenants)
 	}

--- a/internal/tenancy/tenancy_test.go
+++ b/internal/tenancy/tenancy_test.go
@@ -12,6 +12,8 @@ import (
 
 // helpers
 
+const nameKey = "name"
+
 func grafanaOrg(name string, admins, editors, viewers []string, tenantNames []string) *unstructured.Unstructured {
 	toIface := func(ss []string) []interface{} {
 		out := make([]interface{}, len(ss))
@@ -22,7 +24,7 @@ func grafanaOrg(name string, admins, editors, viewers []string, tenantNames []st
 	}
 	tenants := make([]interface{}, len(tenantNames))
 	for i, t := range tenantNames {
-		tenants[i] = map[string]interface{}{"name": t}
+		tenants[i] = map[string]interface{}{nameKey: t}
 	}
 	rbac := map[string]interface{}{}
 	if len(admins) > 0 {
@@ -38,7 +40,7 @@ func grafanaOrg(name string, admins, editors, viewers []string, tenantNames []st
 		Object: map[string]interface{}{
 			"apiVersion": "observability.giantswarm.io/v1alpha2",
 			"kind":       "GrafanaOrganization",
-			"metadata":   map[string]interface{}{"name": name},
+			"metadata":   map[string]interface{}{nameKey: name},
 			"spec": map[string]interface{}{
 				"rbac":    rbac,
 				"tenants": tenants,
@@ -87,12 +89,12 @@ func TestSelectOrgIDNoTenants(t *testing.T) {
 }
 
 func TestSelectOrgIDSingleTenantNoOverride(t *testing.T) {
-	got, err := SelectOrgID([]string{"prod-eu"}, "")
+	got, err := SelectOrgID([]string{tenantProdEU}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != "prod-eu" {
-		t.Errorf("expected %q, got %q", "prod-eu", got)
+	if got != tenantProdEU {
+		t.Errorf("expected %q, got %q", tenantProdEU, got)
 	}
 }
 
@@ -146,10 +148,10 @@ func TestSelectOrgIDPipeSeparatedInvalid(t *testing.T) {
 // --- Resolver.TenantsForGroups ---
 
 func TestTenantsForGroupsMatch(t *testing.T) {
-	org := grafanaOrg("my-org", []string{"team-ops"}, nil, nil, []string{"prod-eu", "prod-us"})
+	org := grafanaOrg("my-org", []string{groupTeamOps}, nil, nil, []string{tenantProdEU, tenantProdUS})
 	r := newTestResolver(org)
 
-	tenants, err := r.TenantsForGroups(context.Background(), []string{"team-ops"})
+	tenants, err := r.TenantsForGroups(context.Background(), []string{groupTeamOps})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,13 +159,13 @@ func TestTenantsForGroupsMatch(t *testing.T) {
 		t.Fatalf("expected 2 tenants, got %v", tenants)
 	}
 	// Result is sorted
-	if tenants[0] != "prod-eu" || tenants[1] != "prod-us" {
+	if tenants[0] != tenantProdEU || tenants[1] != tenantProdUS {
 		t.Errorf("unexpected tenants: %v", tenants)
 	}
 }
 
 func TestTenantsForGroupsNoMatch(t *testing.T) {
-	org := grafanaOrg("my-org", []string{"team-ops"}, nil, nil, []string{"prod-eu"})
+	org := grafanaOrg("my-org", []string{groupTeamOps}, nil, nil, []string{tenantProdEU})
 	r := newTestResolver(org)
 
 	tenants, err := r.TenantsForGroups(context.Background(), []string{"other-team"})
@@ -176,14 +178,14 @@ func TestTenantsForGroupsNoMatch(t *testing.T) {
 }
 
 func TestTenantsForGroupsEditorMatch(t *testing.T) {
-	org := grafanaOrg("my-org", nil, []string{"team-dev"}, nil, []string{"staging"})
+	org := grafanaOrg("my-org", nil, []string{groupTeamDev}, nil, []string{tenantStaging})
 	r := newTestResolver(org)
 
-	tenants, err := r.TenantsForGroups(context.Background(), []string{"team-dev"})
+	tenants, err := r.TenantsForGroups(context.Background(), []string{groupTeamDev})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(tenants) != 1 || tenants[0] != "staging" {
+	if len(tenants) != 1 || tenants[0] != tenantStaging {
 		t.Errorf("expected [staging], got %v", tenants)
 	}
 }
@@ -203,11 +205,11 @@ func TestTenantsForGroupsViewerMatch(t *testing.T) {
 
 func TestTenantsForGroupsDeduplication(t *testing.T) {
 	// Two orgs with overlapping tenants — result should be deduplicated.
-	org1 := grafanaOrg("org1", []string{"team-ops"}, nil, nil, []string{"shared", "prod-eu"})
-	org2 := grafanaOrg("org2", []string{"team-ops"}, nil, nil, []string{"shared", "prod-us"})
+	org1 := grafanaOrg("org1", []string{groupTeamOps}, nil, nil, []string{"shared", tenantProdEU})
+	org2 := grafanaOrg("org2", []string{groupTeamOps}, nil, nil, []string{"shared", tenantProdUS})
 	r := newTestResolver(org1, org2)
 
-	tenants, err := r.TenantsForGroups(context.Background(), []string{"team-ops"})
+	tenants, err := r.TenantsForGroups(context.Background(), []string{groupTeamOps})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,15 +219,15 @@ func TestTenantsForGroupsDeduplication(t *testing.T) {
 }
 
 func TestTenantsForGroupsCaching(t *testing.T) {
-	org := grafanaOrg("my-org", []string{"team-ops"}, nil, nil, []string{"prod-eu"})
+	org := grafanaOrg("my-org", []string{groupTeamOps}, nil, nil, []string{tenantProdEU})
 	r := newTestResolver(org)
 
-	tenants1, err := r.TenantsForGroups(context.Background(), []string{"team-ops"})
+	tenants1, err := r.TenantsForGroups(context.Background(), []string{groupTeamOps})
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Second call should return cached result (same slice)
-	tenants2, err := r.TenantsForGroups(context.Background(), []string{"team-ops"})
+	tenants2, err := r.TenantsForGroups(context.Background(), []string{groupTeamOps})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +242,7 @@ func TestTenantsForGroupsEmptyOrg(t *testing.T) {
 		Object: map[string]interface{}{
 			"apiVersion": "observability.giantswarm.io/v1alpha2",
 			"kind":       "GrafanaOrganization",
-			"metadata":   map[string]interface{}{"name": "empty-org"},
+			"metadata":   map[string]interface{}{nameKey: "empty-org"},
 		},
 	}
 	r := newTestResolver(empty)

--- a/internal/tools/prometheus/input_validation_test.go
+++ b/internal/tools/prometheus/input_validation_test.go
@@ -27,7 +27,7 @@ func TestInputSchemaValidation_RejectsUnknownProperty(t *testing.T) {
 	srv, _, cleanup := newValidatingServer(t)
 	defer cleanup()
 
-	resp := dispatchToolCall(t, srv, "execute_query", map[string]any{
+	resp := dispatchToolCall(t, srv, toolExecuteQuery, map[string]any{
 		"quary": "up", // intentional typo of "query"
 	})
 
@@ -82,8 +82,8 @@ func TestInputSchemaValidation_AcceptsKnownProperty(t *testing.T) {
 	srv, mockURL, cleanup := newValidatingServer(t)
 	defer cleanup()
 
-	resp := dispatchToolCall(t, srv, "execute_query", map[string]any{
-		"query":          "up",
+	resp := dispatchToolCall(t, srv, toolExecuteQuery, map[string]any{
+		paramKeyQuery:    "up",
 		"prometheus_url": mockURL,
 	})
 
@@ -116,8 +116,8 @@ func newValidatingServer(t *testing.T) (*mcpserver.MCPServer, string, func()) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == apiQueryPath {
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"status": "success",
-				"data":   map[string]any{"resultType": "vector", "result": []any{}},
+				respKeyStatus: respValSuccess,
+				respKeyData:   map[string]any{respKeyResultType: respValVector, respKeyResult: []any{}},
 			})
 			return
 		}

--- a/internal/tools/prometheus/tools.go
+++ b/internal/tools/prometheus/tools.go
@@ -73,6 +73,20 @@ const (
 	// tool. Use it for tools whose output is bounded in practice
 	// (get_build_info, get_flags, …).
 	noTruncation = ""
+
+	// contentTypeText is the discriminator value used in mcp.TextContent.Type
+	// for plain-text MCP tool responses.
+	contentTypeText = "text"
+
+	// toolExecuteQuery is the registered name of the PromQL instant-query tool.
+	toolExecuteQuery = "execute_query"
+
+	// toolExecuteRangeQuery is the registered name of the PromQL range-query tool.
+	toolExecuteRangeQuery = "execute_range_query"
+
+	// errQueryParameterRequired is returned when a query handler is called without
+	// the required "query" argument.
+	errQueryParameterRequired = "Error: query parameter is required and must be a string"
 )
 
 // Common parameter builders to reduce repetition
@@ -145,7 +159,7 @@ type ToolMiddleware func(
 // no other safety valve.
 func allowsUnlimited(name string) bool {
 	switch name {
-	case "execute_query", "execute_range_query":
+	case toolExecuteQuery, toolExecuteRangeQuery:
 		return true
 	}
 	return false
@@ -211,7 +225,7 @@ func withDynamicPrometheusClient(handler PrometheusHandler, client *Client, sc *
 				IsError: true,
 				Content: []mcp.Content{
 					mcp.TextContent{
-						Type: "text",
+						Type: contentTypeText,
 						Text: fmt.Sprintf("Error creating Prometheus client: %v", err),
 					},
 				},
@@ -269,13 +283,13 @@ func RegisterPrometheusTools(s *mcpserver.MCPServer, sc *server.ServerContext, m
 	}
 
 	// Query execution tools
-	registerPrometheusTools(s, client, sc, middleware, "execute_query", "Execute a PromQL instant query against Prometheus",
+	registerPrometheusTools(s, client, sc, middleware, toolExecuteQuery, "Execute a PromQL instant query against Prometheus",
 		TruncationAdvice, handleExecuteQuery, withQueryEnhancementParams(
 			mcp.WithString("query", mcp.Required(), mcp.Description("PromQL query string")),
 			mcp.WithString("time", mcp.Description("Optional RFC3339 or Unix timestamp (default: current time)")),
 		)...)
 
-	registerPrometheusTools(s, client, sc, middleware, "execute_range_query", "Execute a PromQL range query with start time, end time, and step interval",
+	registerPrometheusTools(s, client, sc, middleware, toolExecuteRangeQuery, "Execute a PromQL range query with start time, end time, and step interval",
 		TruncationAdvice, handleExecuteRangeQuery, withQueryEnhancementParams(
 			mcp.WithString("query", mcp.Required(), mcp.Description("PromQL query string")),
 			mcp.WithString("start", mcp.Required(), mcp.Description("Start time as RFC3339 or Unix timestamp")),
@@ -504,8 +518,8 @@ func handleExecuteQuery(ctx context.Context, request mcp.CallToolRequest, client
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
-					Text: "Error: query parameter is required and must be a string",
+					Type: contentTypeText,
+					Text: errQueryParameterRequired,
 				},
 			},
 		}, nil
@@ -539,7 +553,7 @@ func handleExecuteQuery(ctx context.Context, request mcp.CallToolRequest, client
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error executing query: %v", err),
 				},
 			},
@@ -551,7 +565,7 @@ func handleExecuteQuery(ctx context.Context, request mcp.CallToolRequest, client
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: formattedResult,
 			},
 		},
@@ -568,8 +582,8 @@ func handleExecuteRangeQuery(ctx context.Context, request mcp.CallToolRequest, c
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
-					Text: "Error: query parameter is required and must be a string",
+					Type: contentTypeText,
+					Text: errQueryParameterRequired,
 				},
 			},
 		}, nil
@@ -581,7 +595,7 @@ func handleExecuteRangeQuery(ctx context.Context, request mcp.CallToolRequest, c
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: "Error: start parameter is required and must be a string",
 				},
 			},
@@ -594,7 +608,7 @@ func handleExecuteRangeQuery(ctx context.Context, request mcp.CallToolRequest, c
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: "Error: end parameter is required and must be a string",
 				},
 			},
@@ -607,7 +621,7 @@ func handleExecuteRangeQuery(ctx context.Context, request mcp.CallToolRequest, c
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: "Error: step parameter is required and must be a string",
 				},
 			},
@@ -640,7 +654,7 @@ func handleExecuteRangeQuery(ctx context.Context, request mcp.CallToolRequest, c
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error executing range query: %v", err),
 				},
 			},
@@ -652,7 +666,7 @@ func handleExecuteRangeQuery(ctx context.Context, request mcp.CallToolRequest, c
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: formattedResult,
 			},
 		},
@@ -669,7 +683,7 @@ func handleGetMetricMetadata(ctx context.Context, request mcp.CallToolRequest, c
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: "Error: metric parameter is required and must be a string",
 				},
 			},
@@ -688,7 +702,7 @@ func handleGetMetricMetadata(ctx context.Context, request mcp.CallToolRequest, c
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error getting metadata for metric '%s': %v", metric, err),
 				},
 			},
@@ -698,7 +712,7 @@ func handleGetMetricMetadata(ctx context.Context, request mcp.CallToolRequest, c
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: fmt.Sprintf("Metadata for metric '%s':\n%+v", metric, metadata),
 			},
 		},
@@ -716,7 +730,7 @@ func handleGetTargets(ctx context.Context, request mcp.CallToolRequest, client *
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error getting targets: %v", err),
 				},
 			},
@@ -733,7 +747,7 @@ func handleGetTargets(ctx context.Context, request mcp.CallToolRequest, client *
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: result,
 			},
 		},
@@ -761,7 +775,7 @@ func handleListLabelNames(ctx context.Context, request mcp.CallToolRequest, clie
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error listing label names: %v", err),
 				},
 			},
@@ -785,7 +799,7 @@ func handleListLabelNames(ctx context.Context, request mcp.CallToolRequest, clie
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: responseText,
 			},
 		},
@@ -802,7 +816,7 @@ func handleListLabelValues(ctx context.Context, request mcp.CallToolRequest, cli
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: "Error: label parameter is required and must be a string",
 				},
 			},
@@ -824,7 +838,7 @@ func handleListLabelValues(ctx context.Context, request mcp.CallToolRequest, cli
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error listing label values for '%s': %v", label, err),
 				},
 			},
@@ -853,7 +867,7 @@ func handleListLabelValues(ctx context.Context, request mcp.CallToolRequest, cli
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: responseText,
 			},
 		},
@@ -870,7 +884,7 @@ func handleFindSeries(ctx context.Context, request mcp.CallToolRequest, client *
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: "Error: matches parameter is required and must be an array of strings",
 				},
 			},
@@ -891,7 +905,7 @@ func handleFindSeries(ctx context.Context, request mcp.CallToolRequest, client *
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error finding series: %v", err),
 				},
 			},
@@ -920,7 +934,7 @@ func handleFindSeries(ctx context.Context, request mcp.CallToolRequest, client *
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: responseText,
 			},
 		},
@@ -938,7 +952,7 @@ func handleGetRules(ctx context.Context, request mcp.CallToolRequest, client *Cl
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error getting rules: %v", err),
 				},
 			},
@@ -948,7 +962,7 @@ func handleGetRules(ctx context.Context, request mcp.CallToolRequest, client *Cl
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: fmt.Sprintf("Prometheus Rules:\n%+v", rules),
 			},
 		},
@@ -966,7 +980,7 @@ func handleGetAlerts(ctx context.Context, request mcp.CallToolRequest, client *C
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error getting alerts: %v", err),
 				},
 			},
@@ -976,7 +990,7 @@ func handleGetAlerts(ctx context.Context, request mcp.CallToolRequest, client *C
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: fmt.Sprintf("Active Alerts:\n%+v", alerts),
 			},
 		},
@@ -994,7 +1008,7 @@ func handleGetAlertManagers(ctx context.Context, request mcp.CallToolRequest, cl
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error getting alert managers: %v", err),
 				},
 			},
@@ -1004,7 +1018,7 @@ func handleGetAlertManagers(ctx context.Context, request mcp.CallToolRequest, cl
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: fmt.Sprintf("AlertManager Discovery:\n%+v", alertManagers),
 			},
 		},
@@ -1022,7 +1036,7 @@ func handleGetConfig(ctx context.Context, request mcp.CallToolRequest, client *C
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error getting config: %v", err),
 				},
 			},
@@ -1032,7 +1046,7 @@ func handleGetConfig(ctx context.Context, request mcp.CallToolRequest, client *C
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: fmt.Sprintf("Prometheus Configuration:\n%+v", config),
 			},
 		},
@@ -1050,7 +1064,7 @@ func handleGetFlags(ctx context.Context, request mcp.CallToolRequest, client *Cl
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error getting flags: %v", err),
 				},
 			},
@@ -1060,7 +1074,7 @@ func handleGetFlags(ctx context.Context, request mcp.CallToolRequest, client *Cl
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: fmt.Sprintf("Prometheus Runtime Flags:\n%+v", flags),
 			},
 		},
@@ -1078,7 +1092,7 @@ func handleGetBuildInfo(ctx context.Context, request mcp.CallToolRequest, client
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error getting build info: %v", err),
 				},
 			},
@@ -1088,7 +1102,7 @@ func handleGetBuildInfo(ctx context.Context, request mcp.CallToolRequest, client
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: fmt.Sprintf("Prometheus Build Information:\n%+v", buildInfo),
 			},
 		},
@@ -1106,7 +1120,7 @@ func handleGetRuntimeInfo(ctx context.Context, request mcp.CallToolRequest, clie
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error getting runtime info: %v", err),
 				},
 			},
@@ -1116,7 +1130,7 @@ func handleGetRuntimeInfo(ctx context.Context, request mcp.CallToolRequest, clie
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: fmt.Sprintf("Prometheus Runtime Information:\n%+v", runtimeInfo),
 			},
 		},
@@ -1139,7 +1153,7 @@ func handleGetTSDBStats(ctx context.Context, request mcp.CallToolRequest, client
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error getting TSDB stats: %v", err),
 				},
 			},
@@ -1149,7 +1163,7 @@ func handleGetTSDBStats(ctx context.Context, request mcp.CallToolRequest, client
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: fmt.Sprintf("TSDB Statistics:\n%+v", tsdbStats),
 			},
 		},
@@ -1166,8 +1180,8 @@ func handleQueryExemplars(ctx context.Context, request mcp.CallToolRequest, clie
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
-					Text: "Error: query parameter is required and must be a string",
+					Type: contentTypeText,
+					Text: errQueryParameterRequired,
 				},
 			},
 		}, nil
@@ -1179,7 +1193,7 @@ func handleQueryExemplars(ctx context.Context, request mcp.CallToolRequest, clie
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: "Error: start parameter is required and must be a string",
 				},
 			},
@@ -1192,7 +1206,7 @@ func handleQueryExemplars(ctx context.Context, request mcp.CallToolRequest, clie
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: "Error: end parameter is required and must be a string",
 				},
 			},
@@ -1207,7 +1221,7 @@ func handleQueryExemplars(ctx context.Context, request mcp.CallToolRequest, clie
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error querying exemplars: %v", err),
 				},
 			},
@@ -1217,7 +1231,7 @@ func handleQueryExemplars(ctx context.Context, request mcp.CallToolRequest, clie
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: fmt.Sprintf("Exemplars for query '%s':\n%+v", query, exemplars),
 			},
 		},
@@ -1240,7 +1254,7 @@ func handleGetTargetsMetadata(ctx context.Context, request mcp.CallToolRequest, 
 			IsError: true,
 			Content: []mcp.Content{
 				mcp.TextContent{
-					Type: "text",
+					Type: contentTypeText,
 					Text: fmt.Sprintf("Error getting targets metadata: %v", err),
 				},
 			},
@@ -1250,7 +1264,7 @@ func handleGetTargetsMetadata(ctx context.Context, request mcp.CallToolRequest, 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{
-				Type: "text",
+				Type: contentTypeText,
 				Text: fmt.Sprintf("Targets Metadata:\n%+v", targetsMetadata),
 			},
 		},
@@ -1267,7 +1281,7 @@ func handleCheckReady(ctx context.Context, request mcp.CallToolRequest, client *
 		return &mcp.CallToolResult{
 			IsError: true,
 			Content: []mcp.Content{
-				mcp.TextContent{Type: "text", Text: fmt.Sprintf("Error checking readiness: %v", err)},
+				mcp.TextContent{Type: contentTypeText, Text: fmt.Sprintf("Error checking readiness: %v", err)},
 			},
 		}, nil
 	}
@@ -1276,13 +1290,13 @@ func handleCheckReady(ctx context.Context, request mcp.CallToolRequest, client *
 		return &mcp.CallToolResult{
 			IsError: true,
 			Content: []mcp.Content{
-				mcp.TextContent{Type: "text", Text: fmt.Sprintf("Prometheus is not ready (HTTP %d): %s", status.StatusCode, status.Message)},
+				mcp.TextContent{Type: contentTypeText, Text: fmt.Sprintf("Prometheus is not ready (HTTP %d): %s", status.StatusCode, status.Message)},
 			},
 		}, nil
 	}
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
-			mcp.TextContent{Type: "text", Text: fmt.Sprintf("Prometheus is ready (HTTP %d): %s", status.StatusCode, status.Message)},
+			mcp.TextContent{Type: contentTypeText, Text: fmt.Sprintf("Prometheus is ready (HTTP %d): %s", status.StatusCode, status.Message)},
 		},
 	}, nil
 }

--- a/internal/tools/prometheus/tools_test.go
+++ b/internal/tools/prometheus/tools_test.go
@@ -18,7 +18,20 @@ import (
 	"github.com/giantswarm/mcp-prometheus/internal/server"
 )
 
-const apiQueryPath = "/api/v1/query"
+const (
+	apiQueryPath = "/api/v1/query"
+
+	respKeyStatus       = "status"
+	respKeyData         = "data"
+	respKeyResult       = "result"
+	respKeyResultType   = "resultType"
+	respValSuccess      = "success"
+	respValVector       = "vector"
+	paramKeyQuery       = "query"
+	bodyPrometheusReady = "Prometheus is Ready."
+	readyMsg            = "ready"
+	notReadyMsg         = "not ready"
+)
 
 // discardLogger returns a *slog.Logger that discards all output.
 func discardLogger() *slog.Logger {
@@ -47,8 +60,8 @@ func TestRegisterPrometheusToolsWithMiddleware(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == apiQueryPath {
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"status": "success",
-				"data":   map[string]any{"resultType": "vector", "result": []any{}},
+				respKeyStatus: respValSuccess,
+				respKeyData:   map[string]any{respKeyResultType: respValVector, respKeyResult: []any{}},
 			})
 		} else {
 			w.WriteHeader(http.StatusNotFound)
@@ -96,7 +109,7 @@ func TestRegisterPrometheusToolsWithMiddleware(t *testing.T) {
 	if len(called) == 0 {
 		t.Fatal("expected middleware to be invoked via server dispatch, but called is empty")
 	}
-	if called[0] != "execute_query" {
+	if called[0] != toolExecuteQuery {
 		t.Errorf("expected first middleware call for execute_query, got %q", called[0])
 	}
 }
@@ -154,7 +167,7 @@ func TestClient(t *testing.T) {
 		{
 			name:     "CheckReady",
 			endpoint: "/-/ready",
-			response: "Prometheus is Ready.",
+			response: bodyPrometheusReady,
 			testFunc: func(ctx context.Context, c *Client) error {
 				status, err := c.CheckReady(ctx)
 				if err != nil {
@@ -202,10 +215,10 @@ func TestHandleExecuteQuery(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == apiQueryPath {
 			response := map[string]any{
-				"status": "success",
-				"data": map[string]any{
-					"resultType": "vector",
-					"result":     []any{},
+				respKeyStatus: respValSuccess,
+				respKeyData: map[string]any{
+					respKeyResultType: respValVector,
+					respKeyResult:     []any{},
 				},
 			}
 			_ = json.NewEncoder(w).Encode(response)
@@ -236,9 +249,9 @@ func TestHandleExecuteQuery(t *testing.T) {
 	// Test valid request
 	request := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
-			Name: "execute_query",
+			Name: toolExecuteQuery,
 			Arguments: map[string]any{
-				"query": "up",
+				paramKeyQuery: "up",
 			},
 		},
 	}
@@ -255,7 +268,7 @@ func TestHandleExecuteQuery(t *testing.T) {
 	// Test missing query parameter
 	requestBad := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
-			Name:      "execute_query",
+			Name:      toolExecuteQuery,
 			Arguments: map[string]any{},
 		},
 	}
@@ -275,10 +288,10 @@ func TestHandleExecuteRangeQuery(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v1/query_range" {
 			response := map[string]any{
-				"status": "success",
-				"data": map[string]any{
-					"resultType": "matrix",
-					"result":     []any{},
+				respKeyStatus: respValSuccess,
+				respKeyData: map[string]any{
+					respKeyResultType: "matrix",
+					respKeyResult:     []any{},
 				},
 			}
 			_ = json.NewEncoder(w).Encode(response)
@@ -309,12 +322,12 @@ func TestHandleExecuteRangeQuery(t *testing.T) {
 	// Test valid request
 	request := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
-			Name: "execute_range_query",
+			Name: toolExecuteRangeQuery,
 			Arguments: map[string]any{
-				"query": "up",
-				"start": "2023-01-01T00:00:00Z",
-				"end":   "2023-01-01T01:00:00Z",
-				"step":  "1m",
+				paramKeyQuery: "up",
+				"start":       "2023-01-01T00:00:00Z",
+				"end":         "2023-01-01T01:00:00Z",
+				"step":        "1m",
 			},
 		},
 	}
@@ -334,8 +347,8 @@ func TestHandleGetMetricMetadata(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v1/metadata" {
 			response := map[string]any{
-				"status": "success",
-				"data": map[string]any{
+				respKeyStatus: respValSuccess,
+				respKeyData: map[string]any{
 					"http_requests_total": []any{
 						map[string]any{
 							"type": "counter",
@@ -397,8 +410,8 @@ func TestCheckReady(t *testing.T) {
 		body       string
 		wantReady  bool
 	}{
-		{name: "ready", statusCode: http.StatusOK, body: "Prometheus is Ready.", wantReady: true},
-		{name: "not ready", statusCode: http.StatusServiceUnavailable, body: "Service Unavailable", wantReady: false},
+		{name: readyMsg, statusCode: http.StatusOK, body: bodyPrometheusReady, wantReady: true},
+		{name: notReadyMsg, statusCode: http.StatusServiceUnavailable, body: "Service Unavailable", wantReady: false},
 		{name: "unexpected 500", statusCode: http.StatusInternalServerError, body: "internal error", wantReady: false},
 	}
 
@@ -452,7 +465,7 @@ func TestCheckReadyMimirFallback(t *testing.T) {
 			_, _ = w.Write([]byte("not found"))
 		case "/ready":
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("ready"))
+			_, _ = w.Write([]byte(readyMsg))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -481,18 +494,18 @@ func TestHandleCheckReady(t *testing.T) {
 		wantText    string
 	}{
 		{
-			name:        "ready",
+			name:        readyMsg,
 			statusCode:  http.StatusOK,
-			body:        "Prometheus is Ready.",
+			body:        bodyPrometheusReady,
 			wantIsError: false,
-			wantText:    "ready",
+			wantText:    readyMsg,
 		},
 		{
-			name:        "not ready",
+			name:        notReadyMsg,
 			statusCode:  http.StatusServiceUnavailable,
 			body:        "not yet",
 			wantIsError: true,
-			wantText:    "not ready",
+			wantText:    notReadyMsg,
 		},
 	}
 
@@ -609,8 +622,8 @@ func TestHandleListLabelNamesTruncation(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"status": "success",
-			"data":   names,
+			respKeyStatus: respValSuccess,
+			respKeyData:   names,
 		})
 	}))
 	defer mockServer.Close()
@@ -669,7 +682,7 @@ func TestTruncationMiddleware(t *testing.T) {
 	makeHandler := func(text string) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return &mcp.CallToolResult{
-				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: text}},
+				Content: []mcp.Content{mcp.TextContent{Type: contentTypeText, Text: text}},
 			}, nil
 		}
 	}
@@ -705,21 +718,21 @@ func TestTruncationMiddleware(t *testing.T) {
 		},
 		{
 			name:       "query tool truncates with TruncationAdvice",
-			toolName:   "execute_query",
+			toolName:   toolExecuteQuery,
 			advice:     TruncationAdvice,
 			text:       bigText,
 			wantSuffix: TruncationAdvice,
 		},
 		{
 			name:       "short text passes through untouched",
-			toolName:   "execute_query",
+			toolName:   toolExecuteQuery,
 			advice:     TruncationAdvice,
 			text:       smallText,
 			wantSuffix: "",
 		},
 		{
 			name:       "unlimited=true bypasses on query tool",
-			toolName:   "execute_query",
+			toolName:   toolExecuteQuery,
 			advice:     TruncationAdvice,
 			text:       bigText,
 			unlimited:  true,
@@ -727,7 +740,7 @@ func TestTruncationMiddleware(t *testing.T) {
 		},
 		{
 			name:       "unlimited=true bypasses on range query tool",
-			toolName:   "execute_range_query",
+			toolName:   toolExecuteRangeQuery,
 			advice:     TruncationAdvice,
 			text:       bigText,
 			unlimited:  true,
@@ -783,9 +796,9 @@ func TestTruncationMiddleware(t *testing.T) {
 		h := truncationMiddleware("find_series", discoveryAdvice, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{
-					mcp.TextContent{Type: "text", Text: bigText},
-					mcp.TextContent{Type: "text", Text: smallText},
-					mcp.TextContent{Type: "text", Text: bigText},
+					mcp.TextContent{Type: contentTypeText, Text: bigText},
+					mcp.TextContent{Type: contentTypeText, Text: smallText},
+					mcp.TextContent{Type: contentTypeText, Text: bigText},
 				},
 			}, nil
 		})
@@ -809,7 +822,7 @@ func TestTruncationMiddleware(t *testing.T) {
 
 	t.Run("propagates handler errors without modification", func(t *testing.T) {
 		boom := fmt.Errorf("boom")
-		h := truncationMiddleware("execute_query", TruncationAdvice, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		h := truncationMiddleware(toolExecuteQuery, TruncationAdvice, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return nil, boom
 		})
 		_, err := h(context.Background(), mcp.CallToolRequest{})
@@ -819,10 +832,10 @@ func TestTruncationMiddleware(t *testing.T) {
 	})
 
 	t.Run("preserves IsError flag on tool error results", func(t *testing.T) {
-		h := truncationMiddleware("execute_query", TruncationAdvice, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		h := truncationMiddleware(toolExecuteQuery, TruncationAdvice, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return &mcp.CallToolResult{
 				IsError: true,
-				Content: []mcp.Content{mcp.TextContent{Type: "text", Text: bigText}},
+				Content: []mcp.Content{mcp.TextContent{Type: contentTypeText, Text: bigText}},
 			}, nil
 		})
 		res, _ := h(context.Background(), mcp.CallToolRequest{})


### PR DESCRIPTION
## Summary

`Align files` (#128) rolled out `golangci-lint v2.12.2` with the stricter `goconst` v1.10.0, which surfaced 31 pre-existing repeated-string-literal violations across `internal/`. The `pre-commit` job is currently red on `main` because of these. The check is non-required today but will be required soon.

This PR resolves every violation by extracting the repeated literals into named constants — production constants in production files, test-scoped constants in test files. Where the linter pointed at an existing constant (`tenantProdEU`), it is reused instead of being redeclared.

A handful of secondary literals surfaced once the primary ones were replaced (`success`, `result`, `resultType`, `vector`); they are extracted in the same pass so post-merge `pre-commit` on `main` is green.

### Constants extracted

**Production** (`internal/oauth/setup.go`, `internal/tools/prometheus/tools.go`):
- `storageTypeValkey = "valkey"`
- `contentTypeText = "text"` (replaces 54 occurrences in `mcp.TextContent.Type`)
- `toolExecuteQuery = "execute_query"`
- `toolExecuteRangeQuery = "execute_range_query"`
- `errQueryParameterRequired = "Error: query parameter is required and must be a string"`

**Test-scoped** (across `internal/oauth`, `internal/server`, `internal/tenancy`, `internal/tools/prometheus`):
- OAuth: `testSecret`, `testDexIssuer`, `testMCPIssuer`
- Server: `tenantA`
- Tenancy: extends existing const block — `tenantProdUS`, `tenantStaging`, `groupTeamOps`, `groupTeamDev`, `nameKey`
- Prometheus tools: `respKeyStatus/Data/Result/ResultType`, `respValSuccess/Vector`, `paramKeyQuery`, `bodyPrometheusReady`, `readyMsg`, `notReadyMsg`

No behavioral change. No `//nolint:goconst` suppressions or rule disables.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run --no-config -E gosec -E goconst -E govet --max-same-issues=0 --max-issues-per-linter=0 ./...` — 0 issues (with v2.12.2, the same version CI uses)
- [x] `gofmt -l .` and `goimports -l -local github.com/giantswarm/mcp-prometheus .` — clean
- [x] `go mod tidy` — no changes
- [ ] CI `pre-commit` job passes