### PR TITLE
ci: migrate to architect-orb 8.1.0 multi-arch path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@8.0.2
+  architect: giantswarm/architect@8.1.0
 
 workflows:
   build:
@@ -14,8 +14,9 @@ workflows:
             only: /^v.*/
 
     # Branch builds: amd64 only for faster PR feedback
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-registries
         platforms: "linux/amd64"
         requires:
@@ -27,8 +28,9 @@ workflows:
 
     # Tag builds: push multi-arch image to gsoci (primary registry).
     # Chart push depends on this completing successfully.
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-gsoci-release
         registries-data: "public gsoci.azurecr.io ACR_GSOCI_USERNAME ACR_GSOCI_PASSWORD true"
         requires:
@@ -42,8 +44,9 @@ workflows:
     # Tag builds: push multi-arch image to all registries (including China mirrors).
     # Runs in parallel, does NOT block the chart push. If a mirror is unreachable,
     # only mirror-dependent clusters are affected, not the primary delivery pipeline.
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-all-registries-release
         requires:
         - go-build-mcp-prometheus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `giantswarm/architect` orb to `8.1.0` and migrate all three image pushes from the deprecated `push-to-registries-multiarch` job to `push-to-registries` with `multiarch: true`. Picks up the v8.1.0 QEMU/binfmt auto-registration, hardened buildx bootstrap, and standard OCI image labels.
+
 ### Added
 
 - Added MCP tool annotations (`readOnlyHint`, `openWorldHint`) to all tools to help clients and users assess tool behavior ([#36355](https://github.com/giantswarm/giantswarm/issues/36355)).


### PR DESCRIPTION
## Summary

- Bump `giantswarm/architect` orb to `8.1.0`.
- Migrate all three image pushes (branch amd64, tag gsoci-release, tag all-registries-release) from the deprecated `architect/push-to-registries-multiarch` job to `architect/push-to-registries` with `multiarch: true`.

## Why

`push-to-registries-multiarch` was deprecated in orb v7.0.0 and will be removed in the next major version. v8.1.0 also brings QEMU/binfmt auto-registration, hardened buildx bootstrap, and standard OCI image labels by default.

## Test plan

- [x] Branch CI exercises the new `push-to-registries` (`multiarch: true`, `platforms: linux/amd64`) on this PR.
- [ ] Auto-release tag after merge exercises the full multi-arch (amd64+arm64) tag-build path on both `push-to-gsoci-release` and `push-to-all-registries-release`.

Made with [Cursor](https://cursor.com)