### PR TITLE
chore: drop auto-release.yaml from lint-yaml target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Drop the removed `.github/workflows/auto-release.yaml` from the `lint-yaml` make target.
+
 ## [0.1.80](https://github.com/giantswarm/mcp-prometheus/compare/v0.1.79...v0.1.80) (2026-06-03)
 
 

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -4,7 +4,7 @@
 lint-yaml: ## Run YAML linter
 	@echo "Running YAML linter..."
 	@# Exclude zz_generated files
-	@yamllint .github/workflows/auto-release.yaml .github/workflows/ci.yaml
+	@yamllint .github/workflows/ci.yaml
 
 .PHONY: check
 check: lint-yaml ## Run YAML linter


### PR DESCRIPTION
## Summary

The `.github/workflows/auto-release.yaml` workflow file has been removed at the platform level (in this repo it's being removed by the open alignment PR #198), so the `lint-yaml` make target will fail (`yamllint` errors on the missing file). This drops the reference so `make lint-yaml` works again.

## Test plan

- [ ] `make lint-yaml` succeeds locally
- [ ] `make check` succeeds locally