### PR TITLE
fix(build): use CI-built binary in container image instead of rebuilding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,7 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
-
-WORKDIR /app
-COPY go.mod go.sum ./
-RUN go mod download
-
-COPY . .
-ARG TARGETOS
-ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
-    -ldflags "-w -extldflags '-static'" \
-    -o mcp-prometheus .
-
+# The Go binary is built by CircleCI (architect/go-build) and attached to the
+# build context as <binary>-<os>-<arch>; this image only assembles the runtime.
+# For a local build, produce the binary first:
+#   CGO_ENABLED=0 go build -o mcp-prometheus-linux-amd64 .
 FROM gsoci.azurecr.io/giantswarm/alpine:3.20.3-giantswarm AS certs
 FROM scratch
 
@@ -18,7 +9,9 @@ COPY --from=certs /etc/passwd /etc/passwd
 COPY --from=certs /etc/group /etc/group
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-COPY --from=builder /app/mcp-prometheus /mcp-prometheus
+ARG TARGETOS
+ARG TARGETARCH
+COPY mcp-prometheus-${TARGETOS}-${TARGETARCH} /mcp-prometheus
 USER giantswarm
 
 ENTRYPOINT ["/mcp-prometheus"]


### PR DESCRIPTION
## Summary

- The Dockerfile rebuilt the Go binary in a `golang` builder stage even though CircleCI's `architect/go-build` job already builds and signs `mcp-prometheus-<os>-<arch>` binaries and attaches them to the workspace. The image now copies the prebuilt binary for the target platform — same pattern as muster. Tag-build image pushes stop paying a full Go compile per platform, and the binary that ships is the one CI built and tested.

## Test plan

- [x] Local validation: built `mcp-prometheus-linux-amd64` with `CGO_ENABLED=0 go build` and confirmed `docker build .` succeeds and the binary runs in the image (branch CI does not build the image in this repo; push-to-registries only runs on tags)
- [ ] Branch CI green (go-build + chart tests)

Made with [Cursor](https://cursor.com)