### PR TITLE
feat(oauth): accept Bearer JWTs from trusted issuers

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -137,7 +137,10 @@ func runServe(transport string, debugMode bool, enableOAuth bool,
 			return fmt.Errorf("--enable-oauth is not supported with stdio transport")
 		}
 
-		oauthCfg := oauth.ConfigFromEnv()
+		oauthCfg, err := oauth.ConfigFromEnv()
+		if err != nil {
+			return fmt.Errorf("failed to read OAuth configuration: %w", err)
+		}
 		h, cleanup, err := oauth.NewHandler(shutdownCtx, oauthCfg, logger)
 		if err != nil {
 			return fmt.Errorf("failed to initialise OAuth handler: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/giantswarm/mcp-prometheus
 go 1.26.0
 
 require (
-	github.com/giantswarm/mcp-oauth v0.9.3
+	github.com/giantswarm/mcp-oauth v0.13.0
 	github.com/mark3labs/mcp-go v0.55.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.69.0

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sa
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/giantswarm/mcp-oauth v0.9.3 h1:muG2x9JFeaqXB8eez+tOFA+LQ2DdeJc+xjuWfpIb7PQ=
 github.com/giantswarm/mcp-oauth v0.9.3/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v0.13.0 h1:IW21BnGiNvAsN8Y/FAR2qgOIcYFf1SDpWRTsQsC4RXY=
+github.com/giantswarm/mcp-oauth v0.13.0/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.9.3 h1:muG2x9JFeaqXB8eez+tOFA+LQ2DdeJc+xjuWfpIb7PQ=
-github.com/giantswarm/mcp-oauth v0.9.3/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-oauth v0.13.0 h1:IW21BnGiNvAsN8Y/FAR2qgOIcYFf1SDpWRTsQsC4RXY=
 github.com/giantswarm/mcp-oauth v0.13.0/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

--- a/helm/mcp-prometheus/templates/deployment.yaml
+++ b/helm/mcp-prometheus/templates/deployment.yaml
@@ -144,6 +144,10 @@ spec:
             - name: OAUTH_TRUSTED_AUDIENCES
               value: {{ .Values.app.oauth.trustedAudiences | join "," | quote }}
             {{- end }}
+            {{- if .Values.app.oauth.trustedIssuers }}
+            - name: OAUTH_TRUSTED_ISSUERS
+              value: {{ .Values.app.oauth.trustedIssuers | toJson | quote }}
+            {{- end }}
             {{- end }}
             {{- if $hasStaticGroupMap }}
             - name: TENANCY_STATIC_GROUP_MAP

--- a/helm/mcp-prometheus/values.schema.json
+++ b/helm/mcp-prometheus/values.schema.json
@@ -293,6 +293,60 @@
               "default": [],
               "description": "OAuth client IDs whose tokens are accepted for SSO token forwarding (e.g., from muster)"
             },
+            "trustedIssuers": {
+              "type": "array",
+              "default": [],
+              "description": "External JWT issuers (e.g. muster) whose Bearer tokens are accepted at /mcp; the token's groups claim drives tenancy.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "issuer",
+                  "jwksURL"
+                ],
+                "properties": {
+                  "issuer": {
+                    "type": "string",
+                    "description": "Expected iss claim value."
+                  },
+                  "jwksURL": {
+                    "type": "string",
+                    "description": "JWKS endpoint used to verify token signatures."
+                  },
+                  "allowedAudiences": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Accepted aud values (this server's resource identifier)."
+                  },
+                  "allowedScopes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Cap on scopes accepted from this issuer."
+                  },
+                  "allowedClaims": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Claim name to exact/glob pattern the token must match."
+                  },
+                  "acceptedTypHeaders": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Accepted JWT typ headers. Defaults to [\"at+jwt\"]."
+                  },
+                  "allowPrivateIPJWKS": {
+                    "type": "boolean",
+                    "description": "Allow the JWKS host to resolve to a private/loopback IP. Disables SSRF protection for this issuer's JWKS fetch."
+                  }
+                }
+              }
+            },
             "allowPrivateURLs": {
               "type": "boolean",
               "description": "Allow OIDC discovery against Dex instances whose hostname resolves to a private/RFC-1918 IP. Required when Dex runs on a private management cluster. Bypasses SSRF protection in the HTTP transport layer only — TLS is still enforced."

--- a/helm/mcp-prometheus/values.yaml
+++ b/helm/mcp-prometheus/values.yaml
@@ -197,6 +197,29 @@ app:
     # Default: [] (only accept tokens issued directly to this server's client_id)
     trustedAudiences: []
 
+    # Trusted external JWT issuers for Bearer tokens presented at /mcp.
+    # A token whose `iss` matches an entry is verified against that entry's JWKS
+    # and constraints; its `groups` claim then drives GrafanaOrganization tenancy.
+    # Use this to accept tokens minted by muster.
+    #
+    # Each entry maps to mcp-oauth's TrustedIssuer:
+    #   issuer:             expected `iss` claim (required)
+    #   jwksURL:            JWKS endpoint for signature verification (required)
+    #   allowedAudiences:   accepted `aud` values (this server's resource identifier)
+    #   allowedScopes:      cap on scopes accepted from this issuer (optional)
+    #   allowedClaims:      map of claim → exact/glob pattern the token must match
+    #   acceptedTypHeaders: accepted JWT `typ` headers (default ["at+jwt"])
+    #   allowPrivateIPJWKS: allow a private/loopback JWKS host (disables SSRF guard)
+    #
+    # Example:
+    #   - issuer: "https://muster.example.com"
+    #     jwksURL: "https://muster.example.com/.well-known/jwks.json"
+    #     allowedAudiences: ["https://mcp-prometheus.example.com"]
+    #     acceptedTypHeaders: ["at+jwt"]
+    #     allowPrivateIPJWKS: false
+    # Default: [] (no external issuers trusted)
+    trustedIssuers: []
+
   # Tenancy resolution configuration (only relevant when app.oauth.enabled: true).
   tenancy:
     # Resolution mode.

--- a/internal/oauth/setup.go
+++ b/internal/oauth/setup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"github.com/giantswarm/mcp-oauth/providers/dex"
 	mcpoidc "github.com/giantswarm/mcp-oauth/providers/oidc"
 	"github.com/giantswarm/mcp-oauth/security"
+	mcpserver "github.com/giantswarm/mcp-oauth/server"
 	"github.com/giantswarm/mcp-oauth/storage"
 	"github.com/giantswarm/mcp-oauth/storage/memory"
 	"github.com/giantswarm/mcp-oauth/storage/valkey"
@@ -72,6 +74,12 @@ type Config struct {
 	// Tokens must still be from the configured issuer (Dex) and cryptographically valid.
 	TrustedAudiences []string
 
+	// TrustedIssuers lists external JWT issuers (e.g. muster) whose Bearer tokens
+	// are accepted at the resource-server endpoint. A token whose iss matches an
+	// entry is verified against that entry's JWKS and constraints; its groups
+	// claim then drives tenancy resolution. Populated from OAUTH_TRUSTED_ISSUERS.
+	TrustedIssuers []mcpserver.TrustedIssuer
+
 	// AllowPrivateURLs permits OIDC discovery against Dex instances whose hostname
 	// resolves to a private/internal IP address (e.g. dex.<mc>.<baseDomain> on a
 	// private management cluster). When true, the HTTP client used for OIDC
@@ -83,6 +91,51 @@ type Config struct {
 	AllowPrivateURLs bool
 }
 
+// TrustedIssuerConfig is the JSON shape of a single OAUTH_TRUSTED_ISSUERS entry.
+// It maps to the subset of mcpserver.TrustedIssuer a Prometheus resource server
+// needs: tenancy is group-based, so the subject claim is left at its default.
+type TrustedIssuerConfig struct {
+	Issuer             string            `json:"issuer"`
+	JwksURL            string            `json:"jwksURL"`
+	AllowedAudiences   []string          `json:"allowedAudiences,omitempty"`
+	AllowedScopes      []string          `json:"allowedScopes,omitempty"`
+	AllowedClaims      map[string]string `json:"allowedClaims,omitempty"`
+	AcceptedTypHeaders []string          `json:"acceptedTypHeaders,omitempty"`
+	AllowPrivateIPJWKS bool              `json:"allowPrivateIPJWKS,omitempty"`
+}
+
+// parseTrustedIssuers decodes the OAUTH_TRUSTED_ISSUERS JSON array into
+// mcpserver.TrustedIssuer values. An empty string yields (nil, nil). Each entry
+// must carry a non-empty issuer and jwksURL.
+func parseTrustedIssuers(raw string) ([]mcpserver.TrustedIssuer, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var entries []TrustedIssuerConfig
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		return nil, fmt.Errorf("OAUTH_TRUSTED_ISSUERS: invalid JSON: %w", err)
+	}
+	issuers := make([]mcpserver.TrustedIssuer, 0, len(entries))
+	for i, e := range entries {
+		if e.Issuer == "" {
+			return nil, fmt.Errorf("OAUTH_TRUSTED_ISSUERS[%d]: issuer is required", i)
+		}
+		if e.JwksURL == "" {
+			return nil, fmt.Errorf("OAUTH_TRUSTED_ISSUERS[%d] (%s): jwksURL is required", i, e.Issuer)
+		}
+		issuers = append(issuers, mcpserver.TrustedIssuer{
+			Issuer:             e.Issuer,
+			JwksURL:            e.JwksURL,
+			AllowedAudiences:   e.AllowedAudiences,
+			AllowedScopes:      e.AllowedScopes,
+			AllowedClaims:      e.AllowedClaims,
+			AcceptedTypHeaders: e.AcceptedTypHeaders,
+			AllowPrivateIPJWKS: e.AllowPrivateIPJWKS,
+		})
+	}
+	return issuers, nil
+}
+
 // envTrue is the string value that enables a boolean env var.
 const envTrue = "true"
 
@@ -90,7 +143,9 @@ const envTrue = "true"
 const storageTypeValkey = "valkey"
 
 // ConfigFromEnv builds a Config by reading the standard environment variables.
-func ConfigFromEnv() Config {
+// It returns an error when OAUTH_TRUSTED_ISSUERS holds malformed JSON or an
+// entry is missing a required field.
+func ConfigFromEnv() (Config, error) {
 	cfg := Config{
 		Issuer:                  os.Getenv("MCP_OAUTH_ISSUER"),
 		EncryptionKey:           os.Getenv("MCP_OAUTH_ENCRYPTION_KEY"),
@@ -113,7 +168,12 @@ func ConfigFromEnv() Config {
 			}
 		}
 	}
-	return cfg
+	issuers, err := parseTrustedIssuers(os.Getenv("OAUTH_TRUSTED_ISSUERS"))
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.TrustedIssuers = issuers
+	return cfg, nil
 }
 
 // NewHandler initialises the mcp-oauth Handler from the given Config.
@@ -174,7 +234,12 @@ func newHandlerWithProvider(ctx context.Context, provider providers.Provider, cf
 		TrustedAudiences:              cfg.TrustedAudiences,
 	}
 
-	srv, err := mcpoauth.NewServer(provider, store, store, store, serverCfg, logger)
+	var opts []mcpoauth.ServerOption
+	if len(cfg.TrustedIssuers) > 0 {
+		opts = append(opts, mcpserver.WithTrustedIssuers(cfg.TrustedIssuers))
+	}
+
+	srv, err := mcpoauth.NewServer(provider, store, store, store, serverCfg, logger, opts...)
 	if err != nil {
 		cleanup()
 		return nil, nil, fmt.Errorf("oauth: create server: %w", err)

--- a/internal/oauth/setup_test.go
+++ b/internal/oauth/setup_test.go
@@ -10,9 +10,11 @@ import (
 )
 
 const (
-	testSecret    = "secret"
-	testDexIssuer = "https://dex.example.com"
-	testMCPIssuer = "https://mcp.example.com"
+	testSecret          = "secret"
+	testDexIssuer       = "https://dex.example.com"
+	testMCPIssuer       = "https://mcp.example.com"
+	testMusterIssuer    = "https://muster.example.com"
+	testMusterJwksURL   = "https://muster.example.com/.well-known/jwks.json"
 )
 
 func TestConfigFromEnvDefaults(t *testing.T) {
@@ -259,10 +261,10 @@ func TestParseTrustedIssuersValid(t *testing.T) {
 		t.Fatalf("expected 1 issuer, got %d", len(issuers))
 	}
 	ti := issuers[0]
-	if ti.Issuer != "https://muster.example.com" {
+	if ti.Issuer != testMusterIssuer {
 		t.Errorf("Issuer: got %q", ti.Issuer)
 	}
-	if ti.JwksURL != "https://muster.example.com/.well-known/jwks.json" {
+	if ti.JwksURL != testMusterJwksURL {
 		t.Errorf("JwksURL: got %q", ti.JwksURL)
 	}
 	if len(ti.AllowedAudiences) != 1 || ti.AllowedAudiences[0] != "https://mcp-prometheus.example.com" {
@@ -322,7 +324,7 @@ func TestConfigFromEnvTrustedIssuers(t *testing.T) {
 	if len(cfg.TrustedIssuers) != 1 {
 		t.Fatalf("expected 1 trusted issuer, got %d", len(cfg.TrustedIssuers))
 	}
-	if cfg.TrustedIssuers[0].Issuer != "https://muster.example.com" {
+	if cfg.TrustedIssuers[0].Issuer != testMusterIssuer {
 		t.Errorf("Issuer: got %q", cfg.TrustedIssuers[0].Issuer)
 	}
 }
@@ -341,8 +343,8 @@ func TestNewHandlerWithProviderTrustedIssuers(t *testing.T) {
 		Issuer: testMCPIssuer,
 		TrustedIssuers: []mcpserver.TrustedIssuer{
 			{
-				Issuer:           "https://muster.example.com",
-				JwksURL:          "https://muster.example.com/.well-known/jwks.json",
+				Issuer:           testMusterIssuer,
+				JwksURL:          testMusterJwksURL,
 				AllowedAudiences: []string{testMCPIssuer},
 			},
 		},

--- a/internal/oauth/setup_test.go
+++ b/internal/oauth/setup_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/giantswarm/mcp-oauth/providers/mock"
+	mcpserver "github.com/giantswarm/mcp-oauth/server"
 )
 
 const (
@@ -29,7 +30,10 @@ func TestConfigFromEnvDefaults(t *testing.T) {
 		t.Setenv(key, "")
 	}
 
-	cfg := ConfigFromEnv()
+	cfg, err := ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if cfg.StorageType != "" {
 		t.Errorf("expected empty StorageType by default, got %q", cfg.StorageType)
@@ -59,7 +63,10 @@ func TestConfigFromEnvReadsValues(t *testing.T) {
 	t.Setenv("DEX_CLIENT_SECRET", "dexsecret")
 	t.Setenv("DEX_REDIRECT_URL", "https://app.example.com/oauth/callback")
 
-	cfg := ConfigFromEnv()
+	cfg, err := ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	checks := []struct {
 		name string
@@ -93,7 +100,10 @@ func TestConfigFromEnvReadsValues(t *testing.T) {
 func TestConfigFromEnvAllowPrivateURLs(t *testing.T) {
 	t.Setenv("MCP_OAUTH_ALLOW_PRIVATE_URLS", "true")
 
-	cfg := ConfigFromEnv()
+	cfg, err := ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if !cfg.AllowPrivateURLs {
 		t.Error("expected AllowPrivateURLs == true when MCP_OAUTH_ALLOW_PRIVATE_URLS=true")
 	}
@@ -223,5 +233,126 @@ func TestNewHandlerWithProviderShortEncryptionKey(t *testing.T) {
 	_, _, err := newHandlerWithProvider(context.Background(), p, cfg, slog.Default())
 	if err == nil {
 		t.Error("expected error for short (non-32-byte) encryption key")
+	}
+}
+
+// --- OAUTH_TRUSTED_ISSUERS parsing ---
+
+const testTrustedIssuersJSON = `[
+  {
+    "issuer": "https://muster.example.com",
+    "jwksURL": "https://muster.example.com/.well-known/jwks.json",
+    "allowedAudiences": ["https://mcp-prometheus.example.com"],
+    "allowedScopes": ["prometheus:read"],
+    "allowedClaims": {"sub": "*@giantswarm.io"},
+    "acceptedTypHeaders": ["at+jwt"],
+    "allowPrivateIPJWKS": true
+  }
+]`
+
+func TestParseTrustedIssuersValid(t *testing.T) {
+	issuers, err := parseTrustedIssuers(testTrustedIssuersJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issuers) != 1 {
+		t.Fatalf("expected 1 issuer, got %d", len(issuers))
+	}
+	ti := issuers[0]
+	if ti.Issuer != "https://muster.example.com" {
+		t.Errorf("Issuer: got %q", ti.Issuer)
+	}
+	if ti.JwksURL != "https://muster.example.com/.well-known/jwks.json" {
+		t.Errorf("JwksURL: got %q", ti.JwksURL)
+	}
+	if len(ti.AllowedAudiences) != 1 || ti.AllowedAudiences[0] != "https://mcp-prometheus.example.com" {
+		t.Errorf("AllowedAudiences: got %v", ti.AllowedAudiences)
+	}
+	if len(ti.AllowedScopes) != 1 || ti.AllowedScopes[0] != "prometheus:read" {
+		t.Errorf("AllowedScopes: got %v", ti.AllowedScopes)
+	}
+	if ti.AllowedClaims["sub"] != "*@giantswarm.io" {
+		t.Errorf("AllowedClaims[sub]: got %q", ti.AllowedClaims["sub"])
+	}
+	if len(ti.AcceptedTypHeaders) != 1 || ti.AcceptedTypHeaders[0] != "at+jwt" {
+		t.Errorf("AcceptedTypHeaders: got %v", ti.AcceptedTypHeaders)
+	}
+	if !ti.AllowPrivateIPJWKS {
+		t.Error("AllowPrivateIPJWKS: expected true")
+	}
+}
+
+func TestParseTrustedIssuersEmpty(t *testing.T) {
+	issuers, err := parseTrustedIssuers("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if issuers != nil {
+		t.Errorf("expected nil issuers for empty input, got %v", issuers)
+	}
+}
+
+func TestParseTrustedIssuersMalformed(t *testing.T) {
+	if _, err := parseTrustedIssuers("{not json"); err == nil {
+		t.Error("expected error for malformed JSON")
+	}
+}
+
+func TestParseTrustedIssuersMissingFields(t *testing.T) {
+	cases := map[string]string{
+		"missing issuer":  `[{"jwksURL": "https://muster.example.com/jwks"}]`,
+		"missing jwksURL": `[{"issuer": "https://muster.example.com"}]`,
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseTrustedIssuers(raw); err == nil {
+				t.Errorf("expected error for %s", name)
+			}
+		})
+	}
+}
+
+func TestConfigFromEnvTrustedIssuers(t *testing.T) {
+	t.Setenv("OAUTH_TRUSTED_ISSUERS", testTrustedIssuersJSON)
+
+	cfg, err := ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.TrustedIssuers) != 1 {
+		t.Fatalf("expected 1 trusted issuer, got %d", len(cfg.TrustedIssuers))
+	}
+	if cfg.TrustedIssuers[0].Issuer != "https://muster.example.com" {
+		t.Errorf("Issuer: got %q", cfg.TrustedIssuers[0].Issuer)
+	}
+}
+
+func TestConfigFromEnvTrustedIssuersInvalid(t *testing.T) {
+	t.Setenv("OAUTH_TRUSTED_ISSUERS", "{not json")
+
+	if _, err := ConfigFromEnv(); err == nil {
+		t.Error("expected error for malformed OAUTH_TRUSTED_ISSUERS")
+	}
+}
+
+func TestNewHandlerWithProviderTrustedIssuers(t *testing.T) {
+	p := mock.NewProvider()
+	cfg := Config{
+		Issuer: testMCPIssuer,
+		TrustedIssuers: []mcpserver.TrustedIssuer{
+			{
+				Issuer:           "https://muster.example.com",
+				JwksURL:          "https://muster.example.com/.well-known/jwks.json",
+				AllowedAudiences: []string{testMCPIssuer},
+			},
+		},
+	}
+	h, cleanup, err := newHandlerWithProvider(context.Background(), p, cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cleanup()
+	if h == nil {
+		t.Error("expected non-nil handler")
 	}
 }

--- a/internal/oauth/setup_test.go
+++ b/internal/oauth/setup_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 const (
-	testSecret          = "secret"
-	testDexIssuer       = "https://dex.example.com"
-	testMCPIssuer       = "https://mcp.example.com"
-	testMusterIssuer    = "https://muster.example.com"
-	testMusterJwksURL   = "https://muster.example.com/.well-known/jwks.json"
+	testSecret        = "secret"
+	testDexIssuer     = "https://dex.example.com"
+	testMCPIssuer     = "https://mcp.example.com"
+	testMusterIssuer  = "https://muster.example.com"
+	testMusterJwksURL = "https://muster.example.com/.well-known/jwks.json"
 )
 
 func TestConfigFromEnvDefaults(t *testing.T) {

--- a/internal/tenancy/tenancy_test.go
+++ b/internal/tenancy/tenancy_test.go
@@ -294,5 +294,33 @@ func TestGrafanaOrgGVR(t *testing.T) {
 	}
 }
 
+// Groups carried by a muster-minted (trusted-issuer) token are connector-prefixed
+// per install (e.g. "customer:Panamax_User"). The resolver matches RBAC entries
+// verbatim, so a GrafanaOrganization must list the prefixed form, and the bare
+// (unprefixed) group must not grant access. This locks the prefixed-group flow
+// from a trusted-issuer Bearer JWT through to tenant resolution.
+func TestTenantsForGroupsConnectorPrefixed(t *testing.T) {
+	const prefixedGroup = "customer:Panamax_User"
+	org := grafanaOrg("customer-org", []string{prefixedGroup}, nil, nil, []string{tenantProdEU})
+	r := newTestResolver(org)
+
+	tenants, err := r.TenantsForGroups(context.Background(), []string{prefixedGroup})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tenants) != 1 || tenants[0] != tenantProdEU {
+		t.Fatalf("expected [%s] for prefixed group, got %v", tenantProdEU, tenants)
+	}
+
+	// The unprefixed group must not match the prefixed RBAC entry.
+	tenants, err = r.TenantsForGroups(context.Background(), []string{"Panamax_User"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tenants) != 0 {
+		t.Errorf("expected no tenants for unprefixed group, got %v", tenants)
+	}
+}
+
 // Suppress unused import (metav1 needed for ListOptions reference in resolver.go)
 var _ = metav1.ListOptions{}


### PR DESCRIPTION
## What

mcp-prometheus only wired `OAUTH_TRUSTED_AUDIENCES` (SSO-forwarded Dex ID tokens) and never configured trusted issuers, so a Bearer JWT minted by muster (`iss = muster`) was rejected at `/mcp`. This wires mcp-oauth's `WithTrustedIssuers` so those tokens are accepted, with tenancy resolved from the token's `groups` claim.

- `internal/oauth/setup.go`: parse `OAUTH_TRUSTED_ISSUERS` (JSON array) into `[]server.TrustedIssuer` via a local json-tagged `TrustedIssuerConfig`; validate each entry (`issuer` and `jwksURL` required); pass `server.WithTrustedIssuers(...)` to `NewServer` only when issuers are configured. `ConfigFromEnv` now returns an error so malformed JSON fails fast (single caller updated).
- Tenancy is unchanged: a trusted-issuer JWT's `groups` flow through `handler.UserInfoFromContext` into the existing `GrafanaOrganization` resolver. Group-scoped, never all-users; run with `--tenancy-mode=grafana-organization`.
- Helm: `app.oauth.trustedIssuers` (rendered as the `OAUTH_TRUSTED_ISSUERS` JSON env var) plus a `values.schema.json` entry.

Fields mirror mcp-oauth `TrustedIssuer` (v0.9.3, the version on `main`): `issuer`, `jwksURL`, `allowedAudiences`, `allowedScopes`, `allowedClaims`, `acceptedTypHeaders`, `allowPrivateIPJWKS`. `subjectClaim` is intentionally omitted (tenancy is group-based, not subject-based). No mcp-oauth bump is needed; `WithTrustedIssuers` already ships in the pinned version.

## Tests

`go test ./...` green. New coverage: `OAUTH_TRUSTED_ISSUERS` JSON parse (valid/empty/malformed/missing-field), `ConfigFromEnv` issuer reading, `newHandlerWithProvider` builds with a trusted issuer, and a tenancy regression asserting connector-prefixed groups (`customer:Panamax_User`) resolve while the unprefixed form does not.

The CHANGELOG `### Added` entry is produced by git-cliff from the `feat(oauth):` commit at release time, so it is not hand-edited.

## Notes

End-to-end acceptance depends on muster's `localMint` minting `aud = <mcp-prometheus resource id>`, `typ: at+jwt`, and `groups` (subplan 02). Per-cluster `app.oauth.trustedIssuers` wiring lands in a separate giantswarm-configs PR.