### PR TITLE
feat(oauth): host-scoped private-IP JWKS allowlist for trusted issuers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* `allowPrivateIPJWKSHosts` on `OAUTH_TRUSTED_ISSUERS` entries (and the `app.oauth.trustedIssuers` Helm values): a per-host allowlist for issuers whose JWKS URL resolves to a private/loopback IP, keeping SSRF protection on every other host. Prefer it over the blanket `allowPrivateIPJWKS` flag.
+
 ## [0.1.80](https://github.com/giantswarm/mcp-prometheus/compare/v0.1.79...v0.1.80) (2026-06-03)
 
 

--- a/helm/mcp-prometheus/values.schema.json
+++ b/helm/mcp-prometheus/values.schema.json
@@ -343,6 +343,13 @@
                   "allowPrivateIPJWKS": {
                     "type": "boolean",
                     "description": "Allow the JWKS host to resolve to a private/loopback IP. Disables SSRF protection for this issuer's JWKS fetch."
+                  },
+                  "allowPrivateIPJWKSHosts": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Hostnames whose JWKS URL may resolve to a private/loopback IP. Scopes the private-IP exception to these hosts; every other host stays SSRF-protected. Prefer over allowPrivateIPJWKS."
                   }
                 }
               }

--- a/helm/mcp-prometheus/values.yaml
+++ b/helm/mcp-prometheus/values.yaml
@@ -209,7 +209,9 @@ app:
     #   allowedScopes:      cap on scopes accepted from this issuer (optional)
     #   allowedClaims:      map of claim → exact/glob pattern the token must match
     #   acceptedTypHeaders: accepted JWT `typ` headers (default ["at+jwt"])
-    #   allowPrivateIPJWKS: allow a private/loopback JWKS host (disables SSRF guard)
+    #   allowPrivateIPJWKS:      allow a private/loopback JWKS host (disables SSRF guard)
+    #   allowPrivateIPJWKSHosts: hostnames allowed to resolve to a private/loopback IP;
+    #                            scopes the exception per host, prefer over allowPrivateIPJWKS
     #
     # Example:
     #   - issuer: "https://muster.example.com"

--- a/internal/oauth/setup.go
+++ b/internal/oauth/setup.go
@@ -102,6 +102,10 @@ type TrustedIssuerConfig struct {
 	AllowedClaims      map[string]string `json:"allowedClaims,omitempty"`
 	AcceptedTypHeaders []string          `json:"acceptedTypHeaders,omitempty"`
 	AllowPrivateIPJWKS bool              `json:"allowPrivateIPJWKS,omitempty"`
+	// AllowPrivateIPJWKSHosts scopes the private-IP JWKS exception to an explicit
+	// hostname allowlist, keeping SSRF protection for every other host. Prefer it
+	// over the blanket AllowPrivateIPJWKS flag.
+	AllowPrivateIPJWKSHosts []string `json:"allowPrivateIPJWKSHosts,omitempty"`
 }
 
 // parseTrustedIssuers decodes the OAUTH_TRUSTED_ISSUERS JSON array into
@@ -124,13 +128,14 @@ func parseTrustedIssuers(raw string) ([]mcpserver.TrustedIssuer, error) {
 			return nil, fmt.Errorf("OAUTH_TRUSTED_ISSUERS[%d] (%s): jwksURL is required", i, e.Issuer)
 		}
 		issuers = append(issuers, mcpserver.TrustedIssuer{
-			Issuer:             e.Issuer,
-			JwksURL:            e.JwksURL,
-			AllowedAudiences:   e.AllowedAudiences,
-			AllowedScopes:      e.AllowedScopes,
-			AllowedClaims:      e.AllowedClaims,
-			AcceptedTypHeaders: e.AcceptedTypHeaders,
-			AllowPrivateIPJWKS: e.AllowPrivateIPJWKS,
+			Issuer:                  e.Issuer,
+			JwksURL:                 e.JwksURL,
+			AllowedAudiences:        e.AllowedAudiences,
+			AllowedScopes:           e.AllowedScopes,
+			AllowedClaims:           e.AllowedClaims,
+			AcceptedTypHeaders:      e.AcceptedTypHeaders,
+			AllowPrivateIPJWKS:      e.AllowPrivateIPJWKS,
+			AllowPrivateIPJWKSHosts: e.AllowPrivateIPJWKSHosts,
 		})
 	}
 	return issuers, nil

--- a/internal/oauth/setup_test.go
+++ b/internal/oauth/setup_test.go
@@ -284,6 +284,30 @@ func TestParseTrustedIssuersValid(t *testing.T) {
 	}
 }
 
+func TestParseTrustedIssuersPrivateIPJWKSHosts(t *testing.T) {
+	raw := `[
+  {
+    "issuer": "https://muster.example.com",
+    "jwksURL": "https://muster.example.com/.well-known/jwks.json",
+    "allowPrivateIPJWKSHosts": ["muster.example.com"]
+  }
+]`
+	issuers, err := parseTrustedIssuers(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issuers) != 1 {
+		t.Fatalf("expected 1 issuer, got %d", len(issuers))
+	}
+	ti := issuers[0]
+	if ti.AllowPrivateIPJWKS {
+		t.Error("AllowPrivateIPJWKS: expected false")
+	}
+	if len(ti.AllowPrivateIPJWKSHosts) != 1 || ti.AllowPrivateIPJWKSHosts[0] != "muster.example.com" {
+		t.Errorf("AllowPrivateIPJWKSHosts: got %v", ti.AllowPrivateIPJWKSHosts)
+	}
+}
+
 func TestParseTrustedIssuersEmpty(t *testing.T) {
 	issuers, err := parseTrustedIssuers("")
 	if err != nil {


### PR DESCRIPTION
## What

Adds `allowPrivateIPJWKSHosts` to `OAUTH_TRUSTED_ISSUERS` entries (and the `app.oauth.trustedIssuers` Helm values). It scopes the private-IP JWKS exception to an explicit hostname allowlist, keeping SSRF protection on every other host, instead of the blanket `allowPrivateIPJWKS` boolean.

## Why

On glean, `mcp-prometheus` must fetch muster's JWKS from `muster.glean.azuretest.gigantic.io`, which resolves to the Azure internal LB (a private IP). The only released knob is the global `allowPrivateIPJWKS`, which disables SSRF protection for the issuer entirely. The per-host allowlist already exists upstream in `mcpserver.TrustedIssuer` (mcp-oauth v0.18.2); this surfaces it.

This field was previously implemented but dropped from the squash-merge of #221 (only the test/CHANGELOG changes landed; the `setup.go` wiring was lost). This restores it against current `main`.

## Changes

- `TrustedIssuerConfig` gains `allowPrivateIPJWKSHosts []string`, wired into `mcpserver.TrustedIssuer`.
- Helm `values.schema.json` + `values.yaml` document the field. The deployment template already renders `trustedIssuers` verbatim to JSON, so no template change.
- Test covering per-host parsing.