### PR TITLE
fix: team ownership annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Team ownership: `application.giantswarm.io/team` annotation set to `atlas` (was `planeteers`).
+
 ### Added
 
 * `allowPrivateIPJWKSHosts` on `OAUTH_TRUSTED_ISSUERS` entries (and the `app.oauth.trustedIssuers` Helm values): a per-host allowlist for issuers whose JWKS URL resolves to a private/loopback IP, keeping SSRF protection on every other host. Prefer it over the blanket `allowPrivateIPJWKS` flag.

--- a/helm/mcp-prometheus/Chart.yaml
+++ b/helm/mcp-prometheus/Chart.yaml
@@ -19,4 +19,4 @@ maintainers:
     email: team-planeteers@giantswarm.io
 kubeVersion: ">=1.25.0-0"
 annotations:
-  application.giantswarm.io/team: planeteers
+  application.giantswarm.io/team: atlas


### PR DESCRIPTION
Chart labelled resources `application.giantswarm.io/team: planeteers`; the owning team is atlas. Sets the annotation to `atlas` so team-derived metrics/dashboards/alert-routing attribute correctly.