### PR TITLE
chore: use canonical team ownership annotation key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Use the canonical `io.giantswarm.application.team` annotation key for team ownership (value `atlas` unchanged).
+
 ### Fixed
 
 * Team ownership: `application.giantswarm.io/team` annotation set to `atlas` (was `planeteers`).

--- a/helm/mcp-prometheus/Chart.yaml
+++ b/helm/mcp-prometheus/Chart.yaml
@@ -19,4 +19,4 @@ maintainers:
     email: team-planeteers@giantswarm.io
 kubeVersion: ">=1.25.0-0"
 annotations:
-  application.giantswarm.io/team: atlas
+  io.giantswarm.application.team: atlas

--- a/helm/mcp-prometheus/templates/_helpers.tpl
+++ b/helm/mcp-prometheus/templates/_helpers.tpl
@@ -40,7 +40,7 @@ helm.sh/chart: {{ include "mcp-prometheus.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Follow-up standardization: switch the team-ownership annotation from `application.giantswarm.io/team` to the OCI-standard `io.giantswarm.application.team` key (used by the majority of charts and the dev-experience docs), and point the labels helper at it. Value `atlas` is unchanged; `helm template` still renders `application.giantswarm.io/team: "atlas"`.

The value fix landed earlier in #241; this only aligns the key.