### PR TITLE
feat(oauth): prepare trusted-issuer validation for muster forward-token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* The `helm.sh/chart` label no longer ends with an invalid character when the 63-character truncation of `<name>-<version>` lands on a `.`. Long dev chart versions previously made every labeled resource fail admission (`metadata.labels: Invalid value`), so the chart could not be installed.
 * Team ownership: `application.giantswarm.io/team` annotation set to `atlas` (was `planeteers`).
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* mcp-oauth updated to v1.x.
+* mcp-oauth updated to v1.0.1.
 
 ## [0.1.80](https://github.com/giantswarm/mcp-prometheus/compare/v0.1.79...v0.1.80) (2026-06-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * `allowPrivateIPJWKSHosts` on `OAUTH_TRUSTED_ISSUERS` entries (and the `app.oauth.trustedIssuers` Helm values): a per-host allowlist for issuers whose JWKS URL resolves to a private/loopback IP, keeping SSRF protection on every other host. Prefer it over the blanket `allowPrivateIPJWKS` flag.
+* Delegated (on-behalf-of) requests are logged with the acting agent's subject, issuer, and full RFC 8693 `act` chain.
+
+### Changed
+
+* mcp-oauth updated to v1.x.
 
 ## [0.1.80](https://github.com/giantswarm/mcp-prometheus/compare/v0.1.79...v0.1.80) (2026-06-03)
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/giantswarm/mcp-prometheus
 go 1.26.0
 
 require (
-	github.com/giantswarm/mcp-oauth v1.0.1-0.20260703062538-1217bf33a91a
+	github.com/giantswarm/mcp-oauth v1.0.1
 	github.com/mark3labs/mcp-go v0.55.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.69.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/giantswarm/mcp-prometheus
 go 1.26.0
 
 require (
-	github.com/giantswarm/mcp-oauth v0.18.9
+	github.com/giantswarm/mcp-oauth v1.0.1-0.20260703062538-1217bf33a91a
 	github.com/mark3labs/mcp-go v0.55.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.69.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.18.9 h1:oLrbAirWD5mR1FcCH8NuEfSoB4m1FrYHNIjRzOfK5u4=
-github.com/giantswarm/mcp-oauth v0.18.9/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v1.0.1-0.20260703062538-1217bf33a91a h1:KSiDX814bwwK137BmjuSc+C5x481oil/QD3beWvCAlU=
+github.com/giantswarm/mcp-oauth v1.0.1-0.20260703062538-1217bf33a91a/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v1.0.1-0.20260703062538-1217bf33a91a h1:KSiDX814bwwK137BmjuSc+C5x481oil/QD3beWvCAlU=
-github.com/giantswarm/mcp-oauth v1.0.1-0.20260703062538-1217bf33a91a/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v1.0.1 h1:rc/hCx5r0KftSPT2vU1qdOiSnw0QIdXpQOwoFLzxsSI=
+github.com/giantswarm/mcp-oauth v1.0.1/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/helm/mcp-prometheus/templates/_helpers.tpl
+++ b/helm/mcp-prometheus/templates/_helpers.tpl
@@ -27,7 +27,7 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "mcp-prometheus.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | trimSuffix "_" }}
+{{- regexReplaceAll "[^A-Za-z0-9]+$" (printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63) "" }}
 {{- end }}
 
 {{/*

--- a/helm/mcp-prometheus/values.yaml
+++ b/helm/mcp-prometheus/values.yaml
@@ -205,7 +205,9 @@ app:
     # Each entry maps to mcp-oauth's TrustedIssuer:
     #   issuer:             expected `iss` claim (required)
     #   jwksURL:            JWKS endpoint for signature verification (required)
-    #   allowedAudiences:   accepted `aud` values (this server's resource identifier)
+    #   allowedAudiences:   accepted `aud` values. With muster forwarding its issued
+    #                       token unchanged this is muster's own resource identifier,
+    #                       not a per-backend value.
     #   allowedScopes:      cap on scopes accepted from this issuer (optional)
     #   allowedClaims:      map of claim → exact/glob pattern the token must match
     #   acceptedTypHeaders: accepted JWT `typ` headers (default ["at+jwt"])
@@ -213,12 +215,11 @@ app:
     #   allowPrivateIPJWKSHosts: hostnames allowed to resolve to a private/loopback IP;
     #                            scopes the exception per host, prefer over allowPrivateIPJWKS
     #
-    # Example:
+    # Example (muster forwarding its issued token unchanged):
     #   - issuer: "https://muster.example.com"
-    #     jwksURL: "https://muster.example.com/.well-known/jwks.json"
-    #     allowedAudiences: ["https://mcp-prometheus.example.com"]
-    #     acceptedTypHeaders: ["at+jwt"]
-    #     allowPrivateIPJWKS: false
+    #     jwksURL: "http://muster.muster.svc.cluster.local:8080/.well-known/jwks.json"
+    #     allowedAudiences: ["https://muster.example.com/mcp"]
+    #     allowPrivateIPJWKSHosts: ["muster.muster.svc.cluster.local"]
     # Default: [] (no external issuers trusted)
     trustedIssuers: []
 

--- a/internal/oauth/setup.go
+++ b/internal/oauth/setup.go
@@ -207,8 +207,9 @@ func NewHandler(ctx context.Context, cfg Config, logger *slog.Logger) (*handler.
 		// Inject an HTTP client that allows connections to private/internal IP
 		// ranges. Required when the Dex issuer URL is an internal DNS name that
 		// resolves to an RFC-1918 address (e.g. on a private management cluster).
-		// TLS verification is still enforced by this client.
-		dexCfg.HTTPClient = mcpoidc.NewPrivateIPAllowedHTTPClient(30 * time.Second)
+		// TLS verification is still enforced by this client; a nil CA pool
+		// verifies against the system pool.
+		dexCfg.HTTPClient = mcpoidc.NewPrivateIPAllowedHTTPClient(30*time.Second, nil)
 	}
 	provider, err := dex.NewProvider(dexCfg)
 	if err != nil {

--- a/internal/tools/prometheus/tenancy_logging_test.go
+++ b/internal/tools/prometheus/tenancy_logging_test.go
@@ -1,0 +1,114 @@
+package prometheus
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/giantswarm/mcp-oauth/handler"
+	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
+
+	"github.com/giantswarm/mcp-prometheus/internal/server"
+)
+
+type staticResolver struct {
+	tenants []string
+}
+
+func (r *staticResolver) TenantsForGroups(_ context.Context, _ []string) ([]string, error) {
+	return r.tenants, nil
+}
+
+func newTenancyServerContext(t *testing.T, logBuffer *bytes.Buffer) *server.ServerContext {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(logBuffer, nil))
+	sc, err := server.NewServerContext(t.Context(),
+		server.WithSlogLogger(logger),
+		server.WithOAuthEnabled(true),
+		server.WithTenancyResolver(&staticResolver{tenants: []string{"giantswarm"}}),
+	)
+	if err != nil {
+		t.Fatalf("NewServerContext: %v", err)
+	}
+	return sc
+}
+
+func TestResolveTenantOrgIDLogsDelegatedRequest(t *testing.T) {
+	var logBuffer bytes.Buffer
+	sc := newTenancyServerContext(t, &logBuffer)
+
+	userInfo := &providers.UserInfo{
+		ID:           "quentin@example.com",
+		Issuer:       "https://muster.example.com",
+		Groups:       []string{"customer:giantswarm"},
+		TokenSource:  providers.TokenSourceTrustedIssuer,
+		ActorSubject: "system:serviceaccount:kagent:sre-agent",
+		ActorIssuer:  "https://muster.example.com",
+		ActorChain: []oidc.ActorClaim{
+			{Issuer: "https://muster.example.com", Subject: "system:serviceaccount:kagent:sre-agent"},
+			{Issuer: "https://muster.example.com", Subject: "system:serviceaccount:kagent:planner-agent"},
+		},
+	}
+	ctx := handler.ContextWithUserInfo(t.Context(), userInfo)
+
+	orgID, err := resolveTenantOrgID(ctx, sc, "")
+	if err != nil {
+		t.Fatalf("resolveTenantOrgID: %v", err)
+	}
+	if orgID != "giantswarm" {
+		t.Errorf("orgID = %q, want %q", orgID, "giantswarm")
+	}
+
+	logged := logBuffer.String()
+	for _, want := range []string{
+		"Delegated request",
+		"subject=quentin@example.com",
+		"actor_subject=system:serviceaccount:kagent:sre-agent",
+		"system:serviceaccount:kagent:planner-agent",
+	} {
+		if !bytes.Contains([]byte(logged), []byte(want)) {
+			t.Errorf("log output missing %q; got: %s", want, logged)
+		}
+	}
+}
+
+func TestResolveTenantOrgIDNoDelegationLogForPlainToken(t *testing.T) {
+	var logBuffer bytes.Buffer
+	sc := newTenancyServerContext(t, &logBuffer)
+
+	// A muster-issued human login token carries no act claim and must pass
+	// without a delegation log line.
+	userInfo := &providers.UserInfo{
+		ID:          "quentin@example.com",
+		Issuer:      "https://muster.example.com",
+		Groups:      []string{"customer:giantswarm"},
+		TokenSource: providers.TokenSourceTrustedIssuer,
+	}
+	ctx := handler.ContextWithUserInfo(t.Context(), userInfo)
+
+	orgID, err := resolveTenantOrgID(ctx, sc, "")
+	if err != nil {
+		t.Fatalf("resolveTenantOrgID: %v", err)
+	}
+	if orgID != "giantswarm" {
+		t.Errorf("orgID = %q, want %q", orgID, "giantswarm")
+	}
+	if bytes.Contains(logBuffer.Bytes(), []byte("Delegated request")) {
+		t.Errorf("unexpected delegation log for a token without act: %s", logBuffer.String())
+	}
+}
+
+func TestActorChainSubjects(t *testing.T) {
+	userInfo := &providers.UserInfo{
+		ActorChain: []oidc.ActorClaim{
+			{Subject: "outer"},
+			{Subject: "inner"},
+		},
+	}
+	subjects := actorChainSubjects(userInfo)
+	if len(subjects) != 2 || subjects[0] != "outer" || subjects[1] != "inner" {
+		t.Errorf("actorChainSubjects = %v, want [outer inner]", subjects)
+	}
+}

--- a/internal/tools/prometheus/tenancy_logging_test.go
+++ b/internal/tools/prometheus/tenancy_logging_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/giantswarm/mcp-prometheus/internal/server"
 )
 
+const (
+	testTenant       = "giantswarm"
+	testMusterIssuer = "https://muster.example.com"
+)
+
 type staticResolver struct {
 	tenants []string
 }
@@ -27,7 +32,7 @@ func newTenancyServerContext(t *testing.T, logBuffer *bytes.Buffer) *server.Serv
 	sc, err := server.NewServerContext(t.Context(),
 		server.WithSlogLogger(logger),
 		server.WithOAuthEnabled(true),
-		server.WithTenancyResolver(&staticResolver{tenants: []string{"giantswarm"}}),
+		server.WithTenancyResolver(&staticResolver{tenants: []string{testTenant}}),
 	)
 	if err != nil {
 		t.Fatalf("NewServerContext: %v", err)
@@ -41,14 +46,14 @@ func TestResolveTenantOrgIDLogsDelegatedRequest(t *testing.T) {
 
 	userInfo := &providers.UserInfo{
 		ID:           "quentin@example.com",
-		Issuer:       "https://muster.example.com",
+		Issuer:       testMusterIssuer,
 		Groups:       []string{"customer:giantswarm"},
 		TokenSource:  providers.TokenSourceTrustedIssuer,
 		ActorSubject: "system:serviceaccount:kagent:sre-agent",
-		ActorIssuer:  "https://muster.example.com",
+		ActorIssuer:  testMusterIssuer,
 		ActorChain: []oidc.ActorClaim{
-			{Issuer: "https://muster.example.com", Subject: "system:serviceaccount:kagent:sre-agent"},
-			{Issuer: "https://muster.example.com", Subject: "system:serviceaccount:kagent:planner-agent"},
+			{Issuer: testMusterIssuer, Subject: "system:serviceaccount:kagent:sre-agent"},
+			{Issuer: testMusterIssuer, Subject: "system:serviceaccount:kagent:planner-agent"},
 		},
 	}
 	ctx := handler.ContextWithUserInfo(t.Context(), userInfo)
@@ -57,8 +62,8 @@ func TestResolveTenantOrgIDLogsDelegatedRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveTenantOrgID: %v", err)
 	}
-	if orgID != "giantswarm" {
-		t.Errorf("orgID = %q, want %q", orgID, "giantswarm")
+	if orgID != testTenant {
+		t.Errorf("orgID = %q, want %q", orgID, testTenant)
 	}
 
 	logged := logBuffer.String()
@@ -82,7 +87,7 @@ func TestResolveTenantOrgIDNoDelegationLogForPlainToken(t *testing.T) {
 	// without a delegation log line.
 	userInfo := &providers.UserInfo{
 		ID:          "quentin@example.com",
-		Issuer:      "https://muster.example.com",
+		Issuer:      testMusterIssuer,
 		Groups:      []string{"customer:giantswarm"},
 		TokenSource: providers.TokenSourceTrustedIssuer,
 	}
@@ -92,8 +97,8 @@ func TestResolveTenantOrgIDNoDelegationLogForPlainToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveTenantOrgID: %v", err)
 	}
-	if orgID != "giantswarm" {
-		t.Errorf("orgID = %q, want %q", orgID, "giantswarm")
+	if orgID != testTenant {
+		t.Errorf("orgID = %q, want %q", orgID, testTenant)
 	}
 	if bytes.Contains(logBuffer.Bytes(), []byte("Delegated request")) {
 		t.Errorf("unexpected delegation log for a token without act: %s", logBuffer.String())

--- a/internal/tools/prometheus/tools.go
+++ b/internal/tools/prometheus/tools.go
@@ -7,6 +7,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/giantswarm/mcp-oauth/handler"
+	"github.com/giantswarm/mcp-oauth/providers"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
@@ -450,12 +451,34 @@ func resolveTenantOrgID(ctx context.Context, sc *server.ServerContext, explicit 
 		return "", fmt.Errorf("tenancy: no user info in context; token validation may have been skipped")
 	}
 
+	if userInfo.IsOBO() {
+		// Delegated (on-behalf-of) request: record the acting agent for audit.
+		// Authorization stays group-based on the human subject's claims.
+		sc.Logger().Info("Delegated request",
+			"issuer", userInfo.Issuer,
+			"subject", userInfo.ID,
+			"actor_subject", userInfo.ActorSubject,
+			"actor_issuer", userInfo.ActorIssuer,
+			"actor_chain", actorChainSubjects(userInfo),
+		)
+	}
+
 	tenants, err := resolver.TenantsForGroups(ctx, userInfo.Groups)
 	if err != nil {
 		return "", fmt.Errorf("tenancy: resolve tenants: %w", err)
 	}
 
 	return tenancy.SelectOrgID(tenants, explicit)
+}
+
+// actorChainSubjects flattens the RFC 8693 act delegation chain to its subject
+// values, ordered outermost (most recent actor) first.
+func actorChainSubjects(userInfo *providers.UserInfo) []string {
+	subjects := make([]string, 0, len(userInfo.ActorChain))
+	for _, actor := range userInfo.ActorChain {
+		subjects = append(subjects, actor.Subject)
+	}
+	return subjects
 }
 
 // createClientFromParams creates a Prometheus client from request parameters,


### PR DESCRIPTION
Phase 3 (backends) of the OBO single-token refactor. muster validates the caller's on-behalf-of token and forwards it unchanged, so mcp-prometheus validates a single issuer (muster) whose audience is muster's own resource identifier.

- Bump mcp-oauth to `v1.0.1` (the same tag muster pins), adapting the private-URL Dex HTTP client to the new explicit CA-pool parameter.
- Log delegated (on-behalf-of) requests with the acting agent's subject, issuer, and full RFC 8693 act chain. Authorization is unchanged: group-based tenancy on the human subject's claims; muster-issued human tokens without an act claim keep working.
- Update the trustedIssuers values docs to the forward-token shape (audience = muster resource identifier, host-scoped private-IP JWKS exception).

Supersedes the renovate dep bumps #243 and #244.

Part of the forward-token series. Validated end to end on glean.
