### PR TITLE
feat: make Service appProtocol configurable for agentgateway discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `service.appProtocol` Helm value: sets `appProtocol` on the Service's `http` port when non-empty, so `agentgateway` can discover this Service as an MCP backend (e.g. `agentgateway.dev/mcp`). Unset by default; existing installs are unaffected.
 * `allowPrivateIPJWKSHosts` on `OAUTH_TRUSTED_ISSUERS` entries (and the `app.oauth.trustedIssuers` Helm values): a per-host allowlist for issuers whose JWKS URL resolves to a private/loopback IP, keeping SSRF protection on every other host. Prefer it over the blanket `allowPrivateIPJWKS` flag.
 
 ## [0.1.80](https://github.com/giantswarm/mcp-prometheus/compare/v0.1.79...v0.1.80) (2026-06-03)

--- a/helm/mcp-prometheus/templates/service.yaml
+++ b/helm/mcp-prometheus/templates/service.yaml
@@ -11,6 +11,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- with .Values.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
     {{- if .Values.monitoring.enabled }}
     - port: {{ regexFind "[0-9]+$" .Values.app.server.metricsAddr | int }}
       targetPort: metrics

--- a/helm/mcp-prometheus/values.schema.json
+++ b/helm/mcp-prometheus/values.schema.json
@@ -113,6 +113,10 @@
           "type": "integer",
           "minimum": 1,
           "maximum": 65535
+        },
+        "appProtocol": {
+          "type": "string",
+          "description": "Optional appProtocol for the http Service port (e.g. agentgateway.dev/mcp for agentgateway discovery)."
         }
       },
       "required": [

--- a/helm/mcp-prometheus/values.yaml
+++ b/helm/mcp-prometheus/values.yaml
@@ -50,6 +50,10 @@ securityContext:
 service:
   type: ClusterIP
   port: 8080
+  # appProtocol for the http port. Set to "agentgateway.dev/mcp" so agentgateway
+  # discovers this Service as an MCP backend. Left empty by default so existing
+  # installs are unaffected.
+  appProtocol: ""
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Summary

agentgateway requires `appProtocol: agentgateway.dev/mcp` on the Service port to discover a backend as an MCP server. Adds a `service.appProtocol` Helm value, rendered onto the `http` port only when set.

Closes #236