### PR TITLE
feat: support private CA for Dex and JWKS TLS verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `DEX_CA_FILE` environment variable and `app.oauth.dexCASecret` Helm value: verify TLS for Dex and JWKS endpoints against a private/internal CA (added on top of the system trust store). Required on installations where Dex is served with a certificate from a private CA.
 * `service.appProtocol` Helm value: sets `appProtocol` on the Service's `http` port when non-empty, so `agentgateway` can discover this Service as an MCP backend (e.g. `agentgateway.dev/mcp`). Unset by default; existing installs are unaffected.
 * `allowPrivateIPJWKSHosts` on `OAUTH_TRUSTED_ISSUERS` entries (and the `app.oauth.trustedIssuers` Helm values): a per-host allowlist for issuers whose JWKS URL resolves to a private/loopback IP, keeping SSRF protection on every other host. Prefer it over the blanket `allowPrivateIPJWKS` flag.
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ All configuration is via environment variables.
 | `DEX_CLIENT_ID` | **required** | OAuth client ID registered in Dex |
 | `DEX_CLIENT_SECRET` | **required** | OAuth client secret |
 | `DEX_REDIRECT_URL` | **required** | Callback URL (e.g. `https://mcp.example.com/oauth/callback`) |
+| `DEX_CA_FILE` | — | PEM CA file verifying TLS for Dex and JWKS endpoints (private-CA installations). Added on top of the system trust store |
 
 ### Tenancy
 
@@ -247,6 +248,28 @@ DEX_ISSUER_URL=https://dex.mc.my-cluster.example.io   # resolves to 10.x.x.x
 ```
 
 In Helm: `app.oauth.allowPrivateURLs: true`
+
+### Private CA (DEX_CA_FILE)
+
+When Dex is served with a certificate from a private/internal CA (e.g. private management
+clusters), TLS verification fails with `x509: certificate signed by unknown authority`.
+Point `DEX_CA_FILE` at a PEM CA file to add that CA on top of the system trust store.
+The pool verifies the Dex provider connection (OIDC discovery, code flow, userinfo),
+the forwarded-ID-token JWKS endpoint, and trusted-issuer JWKS endpoints.
+
+```bash
+DEX_CA_FILE=/etc/ssl/certs/dex-ca/ca.crt
+```
+
+In Helm, reference a Secret holding the CA certificate:
+
+```yaml
+app:
+  oauth:
+    dexCASecret:
+      name: mcp-prometheus-dex-ca
+      key: ca.crt
+```
 
 ### SSO token forwarding (trustedAudiences)
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -72,6 +72,8 @@ OAuth 2.1 (when --enable-oauth is set):
   DEX_CLIENT_ID                 - Dex OAuth client ID (required)
   DEX_CLIENT_SECRET             - Dex OAuth client secret (required)
   DEX_REDIRECT_URL              - OAuth redirect URL (required)
+  DEX_CA_FILE                   - Optional: PEM CA file for Dex/JWKS TLS verification
+                                  (private-CA installations; added to the system pool)
 
 Tenancy (when --enable-oauth is set):
   --tenancy-mode                - grafana-organization (default) or static

--- a/helm/mcp-prometheus/templates/deployment.yaml
+++ b/helm/mcp-prometheus/templates/deployment.yaml
@@ -128,9 +128,17 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.volumeMounts }}
+          {{- $hasDexCA := and .Values.app.oauth.enabled .Values.app.oauth.dexCASecret.name }}
+          {{- if or .Values.volumeMounts $hasDexCA }}
           volumeMounts:
+            {{- if $hasDexCA }}
+            - name: dex-ca
+              mountPath: /etc/ssl/certs/dex-ca
+              readOnly: true
+            {{- end }}
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- $hasStaticGroupMap := and .Values.app.oauth.enabled (not (empty .Values.app.tenancy.static.groups)) }}
           {{- if or .Values.app.env .Values.app.oauth.enabled $hasStaticGroupMap }}
@@ -148,6 +156,10 @@ spec:
             - name: OAUTH_TRUSTED_ISSUERS
               value: {{ .Values.app.oauth.trustedIssuers | toJson | quote }}
             {{- end }}
+            {{- if .Values.app.oauth.dexCASecret.name }}
+            - name: DEX_CA_FILE
+              value: "/etc/ssl/certs/dex-ca/{{ .Values.app.oauth.dexCASecret.key | default "ca.crt" }}"
+            {{- end }}
             {{- end }}
             {{- if $hasStaticGroupMap }}
             - name: TENANCY_STATIC_GROUP_MAP
@@ -162,9 +174,20 @@ spec:
             - secretRef:
                 name: {{ .Values.app.oauth.existingSecret | default (printf "%s-oauth" (include "mcp-prometheus.fullname" .)) }}
           {{- end }}
-      {{- with .Values.volumes }}
+      {{- $hasDexCA := and .Values.app.oauth.enabled .Values.app.oauth.dexCASecret.name }}
+      {{- if or .Values.volumes $hasDexCA }}
       volumes:
+        {{- if $hasDexCA }}
+        - name: dex-ca
+          secret:
+            secretName: {{ .Values.app.oauth.dexCASecret.name }}
+            items:
+              - key: {{ .Values.app.oauth.dexCASecret.key | default "ca.crt" }}
+                path: {{ .Values.app.oauth.dexCASecret.key | default "ca.crt" }}
+        {{- end }}
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/mcp-prometheus/templates/deployment.yaml
+++ b/helm/mcp-prometheus/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $hasDexCA := and .Values.app.oauth.enabled .Values.app.oauth.dexCASecret.name -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -128,7 +129,6 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- $hasDexCA := and .Values.app.oauth.enabled .Values.app.oauth.dexCASecret.name }}
           {{- if or .Values.volumeMounts $hasDexCA }}
           volumeMounts:
             {{- if $hasDexCA }}
@@ -174,7 +174,6 @@ spec:
             - secretRef:
                 name: {{ .Values.app.oauth.existingSecret | default (printf "%s-oauth" (include "mcp-prometheus.fullname" .)) }}
           {{- end }}
-      {{- $hasDexCA := and .Values.app.oauth.enabled .Values.app.oauth.dexCASecret.name }}
       {{- if or .Values.volumes $hasDexCA }}
       volumes:
         {{- if $hasDexCA }}

--- a/helm/mcp-prometheus/values.schema.json
+++ b/helm/mcp-prometheus/values.schema.json
@@ -260,6 +260,20 @@
               "type": "boolean",
               "description": "Allow unauthenticated dynamic client registration. true only for dev/MCP Inspector; false in production."
             },
+            "dexCASecret": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Secret holding a PEM CA certificate used to verify TLS for Dex and JWKS endpoints (private-CA installations). Empty uses the system trust store alone."
+                },
+                "key": {
+                  "type": "string",
+                  "description": "Key within the Secret holding the CA certificate."
+                }
+              },
+              "additionalProperties": false
+            },
             "storage": {
               "type": "object",
               "properties": {

--- a/helm/mcp-prometheus/values.yaml
+++ b/helm/mcp-prometheus/values.yaml
@@ -176,6 +176,14 @@ app:
     # Set to true only when the Dex issuer URL uses internal DNS.
     allowPrivateURLs: false
 
+    # Secret holding a PEM CA certificate used to verify TLS for Dex and JWKS
+    # endpoints. Required on installations where Dex is served with a
+    # certificate from a private/internal CA. The CA is added on top of the
+    # system trust store. Leave name empty to use the system trust store alone.
+    dexCASecret:
+      name: ""
+      key: "ca.crt"
+
     # Token storage backend
     storage:
       # "memory" (default, no persistence) or "valkey"

--- a/internal/oauth/setup.go
+++ b/internal/oauth/setup.go
@@ -3,10 +3,12 @@ package oauth
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -89,6 +91,15 @@ type Config struct {
 	// Set MCP_OAUTH_ALLOW_PRIVATE_URLS=true only in trusted internal environments
 	// where the Dex issuer URL uses internal DNS. TLS verification is still enforced.
 	AllowPrivateURLs bool
+
+	// DexCAFile is the path to a PEM-encoded CA certificate file used to verify
+	// TLS for Dex and for JWKS endpoints. Required when Dex is served with a
+	// certificate from a private/internal CA (e.g. on private management
+	// clusters). The pool is passed explicitly to the Dex provider client, the
+	// forwarded-ID-token JWKS validation, and trusted-issuer JWKS clients —
+	// mcp-oauth does not read a CA installed on http.DefaultTransport.
+	// Empty means the system trust store alone is used.
+	DexCAFile string
 }
 
 // TrustedIssuerConfig is the JSON shape of a single OAUTH_TRUSTED_ISSUERS entry.
@@ -165,9 +176,10 @@ func ConfigFromEnv() (Config, error) {
 		DexClientSecret:         os.Getenv("DEX_CLIENT_SECRET"),
 		DexRedirectURL:          os.Getenv("DEX_REDIRECT_URL"),
 		AllowPrivateURLs:        os.Getenv("MCP_OAUTH_ALLOW_PRIVATE_URLS") == envTrue,
+		DexCAFile:               os.Getenv("DEX_CA_FILE"),
 	}
 	if v := os.Getenv("OAUTH_TRUSTED_AUDIENCES"); v != "" {
-		for _, a := range strings.Split(v, ",") {
+		for a := range strings.SplitSeq(v, ",") {
 			if a = strings.TrimSpace(a); a != "" {
 				cfg.TrustedAudiences = append(cfg.TrustedAudiences, a)
 			}
@@ -203,27 +215,73 @@ func NewHandler(ctx context.Context, cfg Config, logger *slog.Logger) (*handler.
 		// Request groups so the tenant resolver can match GrafanaOrganization RBAC.
 		Scopes: []string{"openid", "profile", "email", "groups", "offline_access"},
 	}
-	if cfg.AllowPrivateURLs {
+	rootCAs, err := loadRootCAs(cfg.DexCAFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("oauth: %w", err)
+	}
+	if rootCAs != nil {
+		logger.Info("Using custom CA for Dex and JWKS TLS verification", "caFile", cfg.DexCAFile)
+	}
+	switch {
+	case cfg.AllowPrivateURLs:
 		// Inject an HTTP client that allows connections to private/internal IP
 		// ranges. Required when the Dex issuer URL is an internal DNS name that
 		// resolves to an RFC-1918 address (e.g. on a private management cluster).
 		// TLS verification is still enforced by this client. A nil CA pool
-		// selects the system trust store, matching the pre-v1 default (the Dex
-		// issuer here is expected to present a publicly-trusted certificate).
-		dexCfg.HTTPClient = mcpoidc.NewPrivateIPAllowedHTTPClient(30*time.Second, nil)
+		// selects the system trust store.
+		dexCfg.HTTPClient = mcpoidc.NewPrivateIPAllowedHTTPClient(30*time.Second, rootCAs)
+	case rootCAs != nil:
+		dexCfg.HTTPClient = httpClientWithRootCAs(rootCAs)
 	}
 	provider, err := dex.NewProvider(dexCfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("oauth: create Dex provider: %w", err)
 	}
 
-	return newHandlerWithProvider(ctx, provider, cfg, logger)
+	return newHandlerWithProvider(ctx, provider, cfg, rootCAs, logger)
+}
+
+// loadRootCAs builds a certificate pool from the system pool plus the
+// PEM-encoded CA certificate(s) in caFile. An empty caFile yields (nil, nil),
+// selecting the system trust store everywhere the pool is consumed.
+func loadRootCAs(caFile string) (*x509.CertPool, error) {
+	if caFile == "" {
+		return nil, nil
+	}
+	// #nosec G304 -- caFile is operator-provided configuration, not user input
+	caCert, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("read CA file %s: %w", caFile, err)
+	}
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		pool = x509.NewCertPool()
+	}
+	if !pool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("parse CA certificate from %s", caFile)
+	}
+	return pool, nil
+}
+
+// httpClientWithRootCAs returns an HTTP client whose transport verifies TLS
+// against the given root CA pool.
+func httpClientWithRootCAs(pool *x509.CertPool) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    pool,
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+		Timeout: 30 * time.Second,
+	}
 }
 
 // newHandlerWithProvider wires a pre-built provider into the mcp-oauth server.
 // It is separated from NewHandler so that tests can inject a mock provider
-// without requiring a live Dex instance.
-func newHandlerWithProvider(ctx context.Context, provider providers.Provider, cfg Config, logger *slog.Logger) (*handler.Handler, func(), error) {
+// without requiring a live Dex instance. rootCAs verifies JWKS endpoint TLS
+// for forwarded-ID-token validation and trusted issuers; nil = system pool.
+func newHandlerWithProvider(ctx context.Context, provider providers.Provider, cfg Config, rootCAs *x509.CertPool, logger *slog.Logger) (*handler.Handler, func(), error) {
 	enc, err := buildEncryptor(cfg, logger)
 	if err != nil {
 		return nil, nil, err
@@ -239,11 +297,22 @@ func newHandlerWithProvider(ctx context.Context, provider providers.Provider, cf
 		AllowPublicClientRegistration: cfg.AllowPublicRegistration,
 		AllowRefreshTokenRotation:     true,
 		TrustedAudiences:              cfg.TrustedAudiences,
+		JWKSRootCAs:                   rootCAs,
 	}
 
 	var opts []mcpoauth.ServerOption
 	if len(cfg.TrustedIssuers) > 0 {
-		opts = append(opts, mcpserver.WithTrustedIssuers(cfg.TrustedIssuers))
+		issuers := make([]mcpserver.TrustedIssuer, len(cfg.TrustedIssuers))
+		copy(issuers, cfg.TrustedIssuers)
+		for i := range issuers {
+			// Issuers built from OAUTH_TRUSTED_ISSUERS never carry their own
+			// pool, so the Dex CA pool applies to their JWKS TLS as well.
+			// A pre-set per-issuer pool wins.
+			if issuers[i].RootCAs == nil {
+				issuers[i].RootCAs = rootCAs
+			}
+		}
+		opts = append(opts, mcpserver.WithTrustedIssuers(issuers))
 	}
 
 	srv, err := mcpoauth.NewServer(provider, store, store, store, serverCfg, logger, opts...)

--- a/internal/oauth/setup_test.go
+++ b/internal/oauth/setup_test.go
@@ -9,11 +9,14 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -226,7 +229,7 @@ func TestNewHandlerWithProviderMemoryStore(t *testing.T) {
 		Issuer:                  testMCPIssuer,
 		AllowPublicRegistration: true,
 	}
-	h, cleanup, err := newHandlerWithProvider(context.Background(), p, cfg, slog.Default())
+	h, cleanup, err := newHandlerWithProvider(context.Background(), p, cfg, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -244,7 +247,7 @@ func TestNewHandlerWithProviderShortEncryptionKey(t *testing.T) {
 		Issuer:        testMCPIssuer,
 		EncryptionKey: "0102030405", // 5 bytes, not 32
 	}
-	_, _, err := newHandlerWithProvider(context.Background(), p, cfg, slog.Default())
+	_, _, err := newHandlerWithProvider(context.Background(), p, cfg, nil, slog.Default())
 	if err == nil {
 		t.Error("expected error for short (non-32-byte) encryption key")
 	}
@@ -441,7 +444,7 @@ func TestValidateTokenEnforcesTrustedIssuerAllowedClaims(t *testing.T) {
 	h, cleanup, err := newHandlerWithProvider(t.Context(), mock.NewProvider(), Config{
 		Issuer:         testMCPIssuer,
 		TrustedIssuers: issuers,
-	}, slog.Default())
+	}, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("newHandlerWithProvider: %v", err)
 	}
@@ -495,12 +498,169 @@ func TestNewHandlerWithProviderTrustedIssuers(t *testing.T) {
 			},
 		},
 	}
-	h, cleanup, err := newHandlerWithProvider(context.Background(), p, cfg, slog.Default())
+	h, cleanup, err := newHandlerWithProvider(context.Background(), p, cfg, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	defer cleanup()
 	if h == nil {
 		t.Error("expected non-nil handler")
+	}
+}
+
+// --- Dex CA file (private-CA installations) ---
+
+func TestConfigFromEnvDexCAFile(t *testing.T) {
+	t.Setenv("DEX_CA_FILE", "/etc/ssl/certs/dex-ca/ca.crt")
+
+	cfg, err := ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DexCAFile != "/etc/ssl/certs/dex-ca/ca.crt" {
+		t.Errorf("DexCAFile: got %q", cfg.DexCAFile)
+	}
+}
+
+func TestLoadRootCAsEmptyPath(t *testing.T) {
+	pool, err := loadRootCAs("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pool != nil {
+		t.Error("expected nil pool for empty path (system trust store)")
+	}
+}
+
+func TestLoadRootCAsMissingFile(t *testing.T) {
+	if _, err := loadRootCAs(filepath.Join(t.TempDir(), "absent.crt")); err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestLoadRootCAsInvalidPEM(t *testing.T) {
+	caFile := filepath.Join(t.TempDir(), "ca.crt")
+	if err := os.WriteFile(caFile, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadRootCAs(caFile); err == nil {
+		t.Error("expected error for invalid PEM")
+	}
+}
+
+func TestLoadRootCAsValid(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	caFile := filepath.Join(t.TempDir(), "ca.crt")
+	pem := pemEncodeCert(t, server.Certificate())
+	if err := os.WriteFile(caFile, pem, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pool, err := loadRootCAs(caFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pool == nil {
+		t.Fatal("expected non-nil pool")
+	}
+
+	resp, err := httpClientWithRootCAs(pool).Get(server.URL)
+	if err != nil {
+		t.Fatalf("request against pool-verified server: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+}
+
+func pemEncodeCert(t *testing.T, cert *x509.Certificate) []byte {
+	t.Helper()
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}
+
+// TestNewHandlerUnreadableDexCAFile verifies that a configured but unreadable
+// DEX_CA_FILE fails startup instead of silently falling back to the system pool.
+func TestNewHandlerUnreadableDexCAFile(t *testing.T) {
+	cfg := Config{
+		Issuer:          testMCPIssuer,
+		DexIssuerURL:    testDexIssuer,
+		DexClientID:     "mcp-prometheus",
+		DexClientSecret: testSecret,
+		DexRedirectURL:  testMCPIssuer + "/oauth/callback",
+		DexCAFile:       filepath.Join(t.TempDir(), "absent.crt"),
+	}
+	if _, _, err := NewHandler(t.Context(), cfg, slog.Default()); err == nil {
+		t.Error("expected error for unreadable DEX_CA_FILE")
+	}
+}
+
+// TestTrustedIssuerInheritsDexCAPool verifies that trusted issuers without an
+// explicit per-issuer pool have their JWKS TLS verified against the Dex CA pool.
+func TestTrustedIssuerInheritsDexCAPool(t *testing.T) {
+	const keyID = "test-key"
+	const audience = testMCPIssuer
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	jwks := map[string]any{
+		"keys": []map[string]any{{
+			"kty": "RSA",
+			"kid": keyID,
+			"use": "sig",
+			"alg": "RS256",
+			"n":   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+			"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+		}},
+	}
+	jwksServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(jwks); err != nil {
+			t.Errorf("encode JWKS: %v", err)
+		}
+	}))
+	defer jwksServer.Close()
+
+	issuers := []mcpserver.TrustedIssuer{{
+		Issuer:             testMusterIssuer,
+		JwksURL:            jwksServer.URL,
+		AllowedAudiences:   []string{audience},
+		AllowPrivateIPJWKS: true,
+	}}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(jwksServer.Certificate())
+
+	h, cleanup, err := newHandlerWithProvider(t.Context(), mock.NewProvider(), Config{
+		Issuer:         testMCPIssuer,
+		TrustedIssuers: issuers,
+	}, pool, slog.Default())
+	if err != nil {
+		t.Fatalf("newHandlerWithProvider: %v", err)
+	}
+	defer cleanup()
+
+	token := signRS256(t, key,
+		map[string]any{"alg": "RS256", "typ": "at+jwt", "kid": keyID},
+		map[string]any{
+			"iss": testMusterIssuer,
+			"sub": "alice@giantswarm.io",
+			"aud": audience,
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Minute).Unix(),
+		})
+
+	protected := h.ValidateToken(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	protected.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200 with issuer JWKS verified via Dex CA pool, got %d (%s)", rr.Code, rr.Body.String())
 	}
 }

--- a/internal/oauth/setup_test.go
+++ b/internal/oauth/setup_test.go
@@ -33,6 +33,7 @@ const (
 	testTypAtJWT      = "at+jwt"
 	testAlgRS256      = "RS256"
 	testKidHeader     = "kid"
+	testAlgHeader     = "alg"
 )
 
 func TestConfigFromEnvDefaults(t *testing.T) {
@@ -458,7 +459,7 @@ func TestValidateTokenEnforcesTrustedIssuerAllowedClaims(t *testing.T) {
 	}))
 	mintToken := func(sub string) string {
 		return signRS256(t, key,
-			map[string]any{"alg": testAlgRS256, "typ": "at+jwt", "kid": keyID},
+			map[string]any{testAlgHeader: testAlgRS256, "typ": "at+jwt", "kid": keyID},
 			map[string]any{
 				"iss": testMusterIssuer,
 				"sub": sub,
@@ -647,7 +648,7 @@ func TestTrustedIssuerInheritsDexCAPool(t *testing.T) {
 	defer cleanup()
 
 	token := signRS256(t, key,
-		map[string]any{"alg": testAlgRS256, "typ": "at+jwt", "kid": keyID},
+		map[string]any{testAlgHeader: testAlgRS256, "typ": "at+jwt", "kid": keyID},
 		map[string]any{
 			"iss": testMusterIssuer,
 			"sub": "alice@giantswarm.io",

--- a/internal/oauth/setup_test.go
+++ b/internal/oauth/setup_test.go
@@ -30,6 +30,9 @@ const (
 	testMCPIssuer     = "https://mcp.example.com"
 	testMusterIssuer  = "https://muster.example.com"
 	testMusterJwksURL = "https://muster.example.com/.well-known/jwks.json"
+	testTypAtJWT      = "at+jwt"
+	testAlgRS256      = "RS256"
+	testKidHeader     = "kid"
 )
 
 func TestConfigFromEnvDefaults(t *testing.T) {
@@ -291,7 +294,7 @@ func TestParseTrustedIssuersValid(t *testing.T) {
 	if ti.AllowedClaims["sub"] != "*@giantswarm.io" {
 		t.Errorf("AllowedClaims[sub]: got %q", ti.AllowedClaims["sub"])
 	}
-	if len(ti.AcceptedTypHeaders) != 1 || ti.AcceptedTypHeaders[0] != "at+jwt" {
+	if len(ti.AcceptedTypHeaders) != 1 || ti.AcceptedTypHeaders[0] != testTypAtJWT {
 		t.Errorf("AcceptedTypHeaders: got %v", ti.AcceptedTypHeaders)
 	}
 	if !ti.AllowPrivateIPJWKS {
@@ -407,12 +410,12 @@ func TestValidateTokenEnforcesTrustedIssuerAllowedClaims(t *testing.T) {
 	}
 	jwks := map[string]any{
 		"keys": []map[string]any{{
-			"kty": "RSA",
-			"kid": keyID,
-			"use": "sig",
-			"alg": "RS256",
-			"n":   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
-			"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+			"kty":         "RSA",
+			testKidHeader: keyID,
+			"use":         "sig",
+			"alg":         testAlgRS256,
+			"n":           base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+			"e":           base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
 		}},
 	}
 	jwksServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -455,7 +458,7 @@ func TestValidateTokenEnforcesTrustedIssuerAllowedClaims(t *testing.T) {
 	}))
 	mintToken := func(sub string) string {
 		return signRS256(t, key,
-			map[string]any{"alg": "RS256", "typ": "at+jwt", "kid": keyID},
+			map[string]any{"alg": testAlgRS256, "typ": "at+jwt", "kid": keyID},
 			map[string]any{
 				"iss": testMusterIssuer,
 				"sub": sub,
@@ -608,12 +611,12 @@ func TestTrustedIssuerInheritsDexCAPool(t *testing.T) {
 	}
 	jwks := map[string]any{
 		"keys": []map[string]any{{
-			"kty": "RSA",
-			"kid": keyID,
-			"use": "sig",
-			"alg": "RS256",
-			"n":   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
-			"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+			"kty":         "RSA",
+			testKidHeader: keyID,
+			"use":         "sig",
+			"alg":         testAlgRS256,
+			"n":           base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+			"e":           base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
 		}},
 	}
 	jwksServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -644,7 +647,7 @@ func TestTrustedIssuerInheritsDexCAPool(t *testing.T) {
 	defer cleanup()
 
 	token := signRS256(t, key,
-		map[string]any{"alg": "RS256", "typ": "at+jwt", "kid": keyID},
+		map[string]any{"alg": testAlgRS256, "typ": "at+jwt", "kid": keyID},
 		map[string]any{
 			"iss": testMusterIssuer,
 			"sub": "alice@giantswarm.io",


### PR DESCRIPTION
## What

- New `DEX_CA_FILE` env var (optional): path to a PEM CA file verifying TLS for Dex and JWKS endpoints. The CA is added on top of the system trust store.
- The pool is passed explicitly everywhere mcp-oauth needs it since giantswarm/mcp-oauth#495 removed `http.DefaultTransport` reading: the Dex provider HTTP client (OIDC discovery, code flow, userinfo), `server.Config.JWKSRootCAs` (forwarded-ID-token JWKS), and trusted-issuer JWKS clients (per-issuer pools take precedence).
- New chart value `app.oauth.dexCASecret.{name,key}`: mounts the referenced Secret at `/etc/ssl/certs/dex-ca/` and sets `DEX_CA_FILE`, mirroring mcp-kubernetes' `oauth.dex.caSecret`.

## Why

On private installations (e.g. garm), Dex is served with a certificate signed by the installation's private CA (`CN=gigantic.internal`). OAuth-enabled mcp-prometheus crashloops at startup:

```
Error: failed to initialise OAuth handler: oauth: create Dex provider: OIDC discovery failed:
Get "https://dex.garm.gawsprivate.gigantic.io/.well-known/openid-configuration":
tls: failed to verify certificate: x509: certificate signed by unknown authority
```

This has kept the garm HelmRelease in Failed/Stalled state since 2026-07-09 (PagerDuty Q2QL3MHUZKX8LG). mcp-kubernetes already solved this with `DEX_CA_FILE` + a CA Secret delivered via flux-extras; this ports the same pattern. A follow-up PR in giantswarm-management-clusters adds the CA Secret and user-values for garm.
