### PR TITLE
fix(deps): pin transitive modules flagged by the OSS Index scan

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,3 +89,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+// Pin transitive modules flagged by the OSS Index scan (nancy) in CI.
+// go mod tidy would otherwise resolve them below the fixed versions,
+// because nothing imports them directly.
+replace golang.org/x/mod => golang.org/x/mod v0.40.0


### PR DESCRIPTION
The nancy / OSS Index step of `ci/circleci: go-build` is red on every branch of this repo since the latest CVE wave. Nothing here imports the flagged modules directly, so `go mod tidy` keeps resolving them below the fixed versions; this pins the module graph instead (same pattern as muster#1106 / mcp-kubernetes):

golang.org/x/mod -> v0.40.0 (CVE-2026-56864, CVE-2026-56865)

Verified locally: `go mod tidy` (twice, idempotent), `go build ./...`, and the resolved graph (`go list -m all`) now selects the fixed versions.

This unblocks the currently red Renovate and Align-files PRs once their branches are refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)