### PR TITLE
fix(helm): allow content in monitoring.serviceMonitor.labels

### DIFF
--- a/helm/mcp-prometheus/values.schema.json
+++ b/helm/mcp-prometheus/values.schema.json
@@ -257,7 +257,7 @@
                 "null"
             ],
             "description": "Global values shared between all subcharts",
-            "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as the `additionalProperties` setting would otherwise collide with Helm's special 'global' values key."
+            "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as this schema would otherwise not allow Helm's special 'global' values key."
         },
         "image": {
             "type": "object",
@@ -346,7 +346,7 @@
                         },
                         "labels": {
                             "type": "object",
-                            "additionalProperties": false
+                            "additionalProperties": true
                         }
                     }
                 }

--- a/helm/mcp-prometheus/values.schema.json
+++ b/helm/mcp-prometheus/values.schema.json
@@ -257,7 +257,7 @@
                 "null"
             ],
             "description": "Global values shared between all subcharts",
-            "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as this schema would otherwise not allow Helm's special 'global' values key."
+            "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as the `additionalProperties` setting would otherwise collide with Helm's special 'global' values key."
         },
         "image": {
             "type": "object",

--- a/helm/mcp-prometheus/values.yaml
+++ b/helm/mcp-prometheus/values.yaml
@@ -118,7 +118,7 @@ monitoring:
     # interval: 30s
     # scrapeTimeout: 10s
     # Additional labels to add to the ServiceMonitor (e.g. to match a Prometheus selector).
-    labels: {}
+    labels: {}  # @schema additionalProperties: true
 
 nodeSelector: {}
 


### PR DESCRIPTION
The values comment documents `monitoring.serviceMonitor.labels` as "Additional labels to add to the ServiceMonitor (e.g. to match a Prometheus selector)", but the generated schema declared the key with `additionalProperties: false` — so any actual label failed chart validation and the documented use was impossible:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
mcp-prometheus:
- at '/monitoring/serviceMonitor/labels': additional properties 'release' not allowed
```

Hit on spidertron while pointing a stock kube-prometheus-stack (whose `serviceMonitorSelector` matches `release: kube-prometheus-stack`) at the chart's ServiceMonitor.

Fix: `# @schema additionalProperties: true` on the key, schema regenerated through the repo's own pre-commit pipeline (which also refreshed the generator's `$comment` on the `global` key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)