### PR TITLE
feat(oauth): Google provider and tenancy mode none for single-tenant Prometheus behind muster

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Deployed in-cluster at Giant Swarm to give AI assistants authenticated, multi-te
 MCP Prometheus exposes 18 read-only MCP tools that wrap the Prometheus HTTP API:
 instant and range PromQL queries, metric/label/series discovery, target and runtime information, TSDB stats, alerting rules, and exemplars.
 
-When deployed with OAuth enabled it acts as a full **OAuth 2.1 Authorization Server** (backed by Dex/OIDC),
+When deployed with OAuth enabled it acts as a full **OAuth 2.1 Authorization Server** (backed by Dex/OIDC or Google),
 so MCP clients authenticate with the server before any tool call.
 The server then resolves the authenticated user's Mimir tenant IDs and enforces them on every query.
 
@@ -111,8 +111,10 @@ All configuration is via environment variables.
 |---|---|---|
 | `MCP_OAUTH_ISSUER` | **required** | Public base URL of this server (e.g. `https://mcp.example.com`) |
 | `MCP_OAUTH_ENCRYPTION_KEY` | — | 32-byte base64 AES-256-GCM key for token encryption (`openssl rand -base64 32`) |
+| `MCP_OAUTH_PROVIDER` | `dex` | Identity provider: `dex` or `google` (see the provider tables below) |
+| `OAUTH_REDIRECT_URL` | **required** | Callback URL registered at the provider (e.g. `https://mcp.example.com/oauth/callback`). The legacy `DEX_REDIRECT_URL` is still honoured when this is unset |
 | `MCP_OAUTH_ALLOW_PUBLIC_REGISTRATION` | `false` | Allow unauthenticated dynamic client registration (dev/MCP Inspector only) |
-| `MCP_OAUTH_ALLOW_PRIVATE_URLS` | `false` | Allow OIDC discovery against Dex on private/internal IPs (see [below](#allow-private-urls)) |
+| `MCP_OAUTH_ALLOW_PRIVATE_URLS` | `false` | Allow OIDC discovery against Dex on private/internal IPs (see [below](#allow-private-urls)); `dex` only |
 | `OAUTH_TRUSTED_AUDIENCES` | — | Comma-separated client IDs trusted for SSO token forwarding |
 | `OAUTH_STORAGE` | `memory` | Token storage: `memory` or `valkey` |
 | `VALKEY_URL` | — | Valkey/Redis address (required when `OAUTH_STORAGE=valkey`) |
@@ -120,21 +122,35 @@ All configuration is via environment variables.
 | `VALKEY_TLS_ENABLED` | `false` | Enable TLS for Valkey |
 | `VALKEY_KEY_PREFIX` | `mcp:` | Key namespace prefix |
 
-### Dex OIDC provider
+### Dex OIDC provider (`MCP_OAUTH_PROVIDER=dex`)
 
 | Variable | Default | Description |
 |---|---|---|
 | `DEX_ISSUER_URL` | **required** | Dex issuer URL (e.g. `https://dex.mc.example.io`) |
 | `DEX_CLIENT_ID` | **required** | OAuth client ID registered in Dex |
 | `DEX_CLIENT_SECRET` | **required** | OAuth client secret |
-| `DEX_REDIRECT_URL` | **required** | Callback URL (e.g. `https://mcp.example.com/oauth/callback`) |
+| `DEX_REDIRECT_URL` | — | Legacy alias of `OAUTH_REDIRECT_URL`; used when the latter is unset |
 | `DEX_CA_FILE` | — | PEM CA file verifying TLS for Dex and JWKS endpoints (private-CA installations). Added on top of the system trust store |
+
+### Google provider (`MCP_OAUTH_PROVIDER=google`)
+
+| Variable | Default | Description |
+|---|---|---|
+| `GOOGLE_CLIENT_ID` | **required** | OAuth client ID of the Google Cloud OAuth client (`….apps.googleusercontent.com`) |
+| `GOOGLE_CLIENT_SECRET` | **required** | OAuth client secret of that client |
+
+Google's discovery, token and JWKS endpoints are public, so `DEX_CA_FILE` and
+`MCP_OAUTH_ALLOW_PRIVATE_URLS` do not apply (they are ignored with a warning).
+Google ID tokens carry no `groups` claim: pair this provider with
+[tenancy mode `none`](#none-mode-single-tenant-prometheus) or a static all-users tenant list.
 
 ### Tenancy
 
 | Variable | Default | Description |
 |---|---|---|
 | `TENANCY_STATIC_GROUP_MAP` | — | JSON map of Dex group → list of Mimir tenant IDs (static mode) |
+
+Tenancy mode is a flag: `--tenancy-mode grafana-organization|static|none` (see [Multi-tenancy](#multi-tenancy)).
 
 ### Observability
 
@@ -169,7 +185,10 @@ OAuth requires `sse` or `streamable-http`.
 
 ## OAuth 2.1 authentication
 
-MCP Prometheus implements OAuth 2.1 ([RFC 9700][rfc9700]) using [mcp-oauth][mcp-oauth] and [Dex][dex] as the OIDC identity provider.
+MCP Prometheus implements OAuth 2.1 ([RFC 9700][rfc9700]) using [mcp-oauth][mcp-oauth] with the platform's
+identity provider upstream: [Dex][dex] (default) or Google, selected with `MCP_OAUTH_PROVIDER`.
+The flow, endpoints and token handling are identical for both; only the upstream login and the
+provider-specific environment variables differ.
 
 [rfc9700]: https://datatracker.ietf.org/doc/html/rfc9700
 [mcp-oauth]: https://github.com/giantswarm/mcp-oauth
@@ -181,8 +200,8 @@ MCP Prometheus implements OAuth 2.1 ([RFC 9700][rfc9700]) using [mcp-oauth][mcp-
 |---|---|---|
 | `/.well-known/oauth-authorization-server` | GET | OAuth server metadata (RFC 8414) |
 | `/.well-known/protected-resources` | GET | Protected resource metadata |
-| `/oauth/authorize` | GET | Authorization endpoint (redirects to Dex) |
-| `/oauth/callback` | GET | Dex callback |
+| `/oauth/authorize` | GET | Authorization endpoint (redirects to the identity provider) |
+| `/oauth/callback` | GET | Identity provider callback (`OAUTH_REDIRECT_URL`) |
 | `/oauth/token` | POST | Token exchange |
 | `/oauth/register` | POST | Dynamic client registration (RFC 7591) |
 | `/oauth/revoke` | POST | Token revocation |
@@ -274,7 +293,7 @@ app:
 ### SSO token forwarding (trustedAudiences)
 
 When users connect through an upstream MCP aggregator (e.g. [muster][muster]) that has already authenticated them,
-the aggregator can forward the user's Dex ID token directly instead of starting a new OAuth flow.
+the aggregator can forward the user's ID token from the platform IdP directly instead of starting a new OAuth flow.
 
 [muster]: https://github.com/giantswarm/muster
 
@@ -286,10 +305,11 @@ OAUTH_TRUSTED_AUDIENCES=muster-client,my-aggregator
 
 mcp-prometheus will:
 1. Detect that the incoming token's audience matches a trusted client ID
-2. Verify the token signature against Dex's JWKS endpoint
+2. Verify the token signature against the provider's JWKS endpoint (Dex or Google)
 3. Accept the token and proceed with tenant resolution
 
-Tokens **must** still originate from the configured Dex issuer.
+Tokens **must** still originate from the configured provider's issuer. With the Google
+provider, list the platform's Google OAuth client ID (the one muster logs users in with) here.
 
 ---
 
@@ -299,7 +319,8 @@ When OAuth is enabled, every tool call is scoped to the authenticated user's all
 The user can pass an explicit `org_id` parameter; the server validates it against their allowed tenants.
 If no `org_id` is given, all allowed tenants are injected as a Mimir pipe-separated multi-tenant selector.
 
-Two resolution modes are available, selected with `--tenancy-mode` (or `app.tenancy.mode` in Helm).
+Three resolution modes are available, selected with `--tenancy-mode` (or `app.tenancy.mode` in Helm):
+`grafana-organization` (default), `static`, and `none`.
 
 ### GrafanaOrganization mode (default)
 
@@ -374,6 +395,26 @@ app:
 ```
 
 The user's allowed tenants are the union of all tenants from their Dex groups.
+
+### None mode (single-tenant Prometheus)
+
+**`--tenancy-mode none`**
+
+For a plain, single-tenant Prometheus (no Mimir, no `X-Scope-OrgID`). OAuth still
+authenticates every caller — unauthenticated requests are rejected, forwarded tokens are
+validated and the identity is available for auditing — but no tenant is derived from the
+identity and no tenant header is injected. An explicit `org_id` tool parameter or
+`PROMETHEUS_ORGID` passes through verbatim. The chart creates no `ClusterRole` in this mode.
+
+This is the mode to use with the Google provider (Google tokens have no `groups` claim)
+and whenever mcp-prometheus sits behind [muster][muster] in front of a single Prometheus.
+
+Helm:
+```yaml
+app:
+  tenancy:
+    mode: none
+```
 
 ---
 
@@ -475,6 +516,34 @@ app:
       value: "https://mcp-prometheus.mc.example.io/oauth/callback"
     - name: PROMETHEUS_URL
       value: "http://mimir-gateway.monitoring:8080/prometheus"
+```
+
+### Google provider + single-tenant Prometheus behind muster
+
+The platform IdP is Google, muster forwards the user's Google ID token
+(`auth.forwardToken: true`), and there are no Mimir tenants to resolve.
+
+```yaml
+app:
+  oauth:
+    enabled: true
+    provider: google
+    redirectURL: "https://mcp-prometheus.example.io/oauth/callback"
+    google:
+      clientID: "1234567890-abc.apps.googleusercontent.com"   # this server's OAuth client
+    googleClientSecret: "..."   # or existingSecret with key GOOGLE_CLIENT_SECRET
+    encryptionKey: "..."        # openssl rand -base64 32
+    trustedAudiences:
+      - "1234567890-platform.apps.googleusercontent.com"       # the platform client muster logs in with
+
+  tenancy:
+    mode: none
+
+  env:
+    - name: MCP_OAUTH_ISSUER
+      value: "https://mcp-prometheus.example.io"
+    - name: PROMETHEUS_URL
+      value: "http://prometheus-operated.monitoring:9090"
 ```
 
 ### Production with OAuth + static group mapping

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -66,17 +66,29 @@ Environment Variables:
 OAuth 2.1 (when --enable-oauth is set):
   MCP_OAUTH_ISSUER              - OAuth issuer URL (required)
   MCP_OAUTH_ENCRYPTION_KEY      - AES-256-GCM key for token encryption (base64, required)
+  MCP_OAUTH_PROVIDER            - Identity provider: dex (default) or google
+  OAUTH_REDIRECT_URL            - OAuth callback URL, e.g. https://mcp.example.com/oauth/callback
+                                  (required; legacy DEX_REDIRECT_URL is still honoured)
+  OAUTH_TRUSTED_AUDIENCES       - Comma-separated client IDs whose forwarded ID tokens are accepted (SSO)
   OAUTH_STORAGE                 - Storage backend: memory (default) or valkey
   VALKEY_URL                    - Valkey connection URL (when OAUTH_STORAGE=valkey)
+
+  Provider dex:
   DEX_ISSUER_URL                - Dex OIDC issuer URL (required)
   DEX_CLIENT_ID                 - Dex OAuth client ID (required)
   DEX_CLIENT_SECRET             - Dex OAuth client secret (required)
-  DEX_REDIRECT_URL              - OAuth redirect URL (required)
   DEX_CA_FILE                   - Optional: PEM CA file for Dex/JWKS TLS verification
                                   (private-CA installations; added to the system pool)
+  MCP_OAUTH_ALLOW_PRIVATE_URLS  - Optional: allow OIDC discovery against private-IP Dex hosts
+
+  Provider google:
+  GOOGLE_CLIENT_ID              - Google OAuth client ID (required)
+  GOOGLE_CLIENT_SECRET          - Google OAuth client secret (required)
 
 Tenancy (when --enable-oauth is set):
-  --tenancy-mode                - grafana-organization (default) or static
+  --tenancy-mode                - grafana-organization (default), static, or none
+                                  (none: single-tenant Prometheus; OAuth authenticates
+                                  the caller, no tenant header is injected)
   --static-tenants              - Comma-separated tenant IDs for all users (static mode)
   TENANCY_STATIC_GROUP_MAP      - JSON map of group→[tenant IDs] for group-mapping (static mode)
 
@@ -91,7 +103,7 @@ they can be provided as parameters to individual tool calls.`,
 
 	// Add flags for configuring the server
 	cmd.Flags().BoolVar(&debugMode, "debug", false, "Enable debug logging (default: false)")
-	cmd.Flags().BoolVar(&enableOAuth, "enable-oauth", false, "Enable OAuth 2.1 authentication (requires MCP_OAUTH_* and DEX_* env vars; sse/streamable-http only)")
+	cmd.Flags().BoolVar(&enableOAuth, "enable-oauth", false, "Enable OAuth 2.1 authentication (requires MCP_OAUTH_* plus the DEX_* or GOOGLE_* env vars of the selected MCP_OAUTH_PROVIDER; sse/streamable-http only)")
 
 	// Transport flags
 	cmd.Flags().StringVar(&transport, "transport", "stdio", "Transport type: stdio, sse, or streamable-http")
@@ -103,7 +115,7 @@ they can be provided as parameters to individual tool calls.`,
 
 	// Tenancy flags (only relevant when --enable-oauth is set)
 	cmd.Flags().StringVar(&tenancyMode, "tenancy-mode", string(tenancy.ModeGrafanaOrganization),
-		"Tenancy resolution mode when OAuth is enabled: grafana-organization or static")
+		"Tenancy resolution mode when OAuth is enabled: grafana-organization, static, or none (single-tenant Prometheus: OAuth authenticates the caller, no tenant header is injected)")
 	cmd.Flags().StringVar(&staticTenants, "static-tenants", "",
 		"Comma-separated Mimir tenant IDs for all authenticated users (--tenancy-mode=static only)")
 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/helm/mcp-prometheus/README.md
+++ b/helm/mcp-prometheus/README.md
@@ -90,8 +90,12 @@ Kubernetes: `>=1.25.0-0`
 | app.server.debug | bool | `false` |  |
 | app.server.metricsAddr | string | `":9091"` |  |
 | app.oauth.enabled | bool | `false` |  |
+| app.oauth.provider | string | `"dex"` |  |
+| app.oauth.redirectURL | string | `""` |  |
+| app.oauth.google.clientID | string | `""` |  |
 | app.oauth.existingSecret | string | `""` |  |
 | app.oauth.dexClientSecret | string | `""` |  |
+| app.oauth.googleClientSecret | string | `""` |  |
 | app.oauth.encryptionKey | string | `""` |  |
 | app.oauth.allowPublicRegistration | bool | `false` |  |
 | app.oauth.allowPrivateURLs | bool | `false` |  |

--- a/helm/mcp-prometheus/templates/_helpers.tpl
+++ b/helm/mcp-prometheus/templates/_helpers.tpl
@@ -68,3 +68,22 @@ Create the image path
 {{- define "mcp-prometheus.image" -}}
 {{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
 {{- end }}
+
+{{/*
+OAuth identity provider (app.oauth.provider), defaulting to dex and rejecting
+anything the binary does not implement so a typo fails at render time.
+*/}}
+{{- define "mcp-prometheus.oauthProvider" -}}
+{{- $p := .Values.app.oauth.provider | default "dex" -}}
+{{- if not (has $p (list "dex" "google")) -}}
+{{- fail (printf "app.oauth.provider must be one of: dex, google (got %q)" $p) -}}
+{{- end -}}
+{{- $p -}}
+{{- end }}
+
+{{/*
+Effective tenancy mode (app.tenancy.mode), defaulting to grafana-organization.
+*/}}
+{{- define "mcp-prometheus.tenancyMode" -}}
+{{- .Values.app.tenancy.mode | default "grafana-organization" -}}
+{{- end }}

--- a/helm/mcp-prometheus/templates/deployment.yaml
+++ b/helm/mcp-prometheus/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- $hasDexCA := and .Values.app.oauth.enabled .Values.app.oauth.dexCASecret.name -}}
+{{- $oauthProvider := include "mcp-prometheus.oauthProvider" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,7 +53,7 @@ spec:
             - --metrics-addr={{ if .Values.monitoring.enabled }}{{ .Values.app.server.metricsAddr }}{{ end }}
             {{- if .Values.app.oauth.enabled }}
             - --enable-oauth
-            - --tenancy-mode={{ .Values.app.tenancy.mode | default "grafana-organization" }}
+            - --tenancy-mode={{ include "mcp-prometheus.tenancyMode" . }}
             {{- if .Values.app.tenancy.static.tenants }}
             - --static-tenants={{ .Values.app.tenancy.static.tenants }}
             {{- end }}
@@ -144,6 +145,16 @@ spec:
           {{- if or .Values.app.env .Values.app.oauth.enabled $hasStaticGroupMap }}
           env:
             {{- if .Values.app.oauth.enabled }}
+            - name: MCP_OAUTH_PROVIDER
+              value: {{ $oauthProvider | quote }}
+            {{- if .Values.app.oauth.redirectURL }}
+            - name: OAUTH_REDIRECT_URL
+              value: {{ .Values.app.oauth.redirectURL | quote }}
+            {{- end }}
+            {{- if .Values.app.oauth.google.clientID }}
+            - name: GOOGLE_CLIENT_ID
+              value: {{ .Values.app.oauth.google.clientID | quote }}
+            {{- end }}
             - name: MCP_OAUTH_ALLOW_PUBLIC_REGISTRATION
               value: {{ .Values.app.oauth.allowPublicRegistration | quote }}
             - name: MCP_OAUTH_ALLOW_PRIVATE_URLS

--- a/helm/mcp-prometheus/templates/oauth-secret.yaml
+++ b/helm/mcp-prometheus/templates/oauth-secret.yaml
@@ -1,6 +1,13 @@
 {{- if and .Values.app.oauth.enabled (not .Values.app.oauth.existingSecret) -}}
+{{- $provider := include "mcp-prometheus.oauthProvider" . -}}
+{{- if eq $provider "google" -}}
+{{- if not .Values.app.oauth.googleClientSecret -}}
+{{- fail "app.oauth.googleClientSecret is required when OAuth is enabled with app.oauth.provider=google and existingSecret is not set" -}}
+{{- end -}}
+{{- else -}}
 {{- if not .Values.app.oauth.dexClientSecret -}}
-{{- fail "app.oauth.dexClientSecret is required when OAuth is enabled and existingSecret is not set" -}}
+{{- fail "app.oauth.dexClientSecret is required when OAuth is enabled with app.oauth.provider=dex and existingSecret is not set" -}}
+{{- end -}}
 {{- end -}}
 {{- if not .Values.app.oauth.encryptionKey -}}
 {{- fail "app.oauth.encryptionKey is required when OAuth is enabled and existingSecret is not set. Generate with: openssl rand -base64 32" -}}
@@ -13,7 +20,11 @@ metadata:
     {{- include "mcp-prometheus.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if eq $provider "google" }}
+  GOOGLE_CLIENT_SECRET: {{ .Values.app.oauth.googleClientSecret | b64enc | quote }}
+  {{- else }}
   DEX_CLIENT_SECRET: {{ .Values.app.oauth.dexClientSecret | b64enc | quote }}
+  {{- end }}
   MCP_OAUTH_ENCRYPTION_KEY: {{ .Values.app.oauth.encryptionKey | b64enc | quote }}
   {{- if .Values.app.oauth.storage.valkey.password }}
   VALKEY_PASSWORD: {{ .Values.app.oauth.storage.valkey.password | b64enc | quote }}

--- a/helm/mcp-prometheus/templates/rbac.yaml
+++ b/helm/mcp-prometheus/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- $needsK8s := and .Values.app.oauth.enabled (ne .Values.app.tenancy.mode "static") -}}
+{{- $needsK8s := and .Values.app.oauth.enabled (eq (include "mcp-prometheus.tenancyMode" .) "grafana-organization") -}}
 {{- if and .Values.serviceAccount.create $needsK8s -}}
 {{/*
 ClusterRole granting the mcp-prometheus ServiceAccount read access to
@@ -6,8 +6,8 @@ GrafanaOrganization CRDs so the tenancy resolver can map authenticated
 user groups to Mimir tenant IDs.
 
 This resource is only created when OAuth 2.1 is enabled
-(app.oauth.enabled: true), because without OAuth the server does not
-perform tenancy resolution.
+(app.oauth.enabled: true) and app.tenancy.mode is grafana-organization;
+the static and none modes never touch the Kubernetes API.
 */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm/mcp-prometheus/values.schema.json
+++ b/helm/mcp-prometheus/values.schema.json
@@ -275,7 +275,7 @@
                 "null"
             ],
             "description": "Global values shared between all subcharts",
-            "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as this schema would otherwise not allow Helm's special 'global' values key."
+            "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as the `additionalProperties` setting would otherwise collide with Helm's special 'global' values key."
         },
         "image": {
             "type": "object",

--- a/helm/mcp-prometheus/values.schema.json
+++ b/helm/mcp-prometheus/values.schema.json
@@ -48,6 +48,24 @@
                         "existingSecret": {
                             "type": "string"
                         },
+                        "google": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "clientID": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "googleClientSecret": {
+                            "type": "string"
+                        },
+                        "provider": {
+                            "type": "string"
+                        },
+                        "redirectURL": {
+                            "type": "string"
+                        },
                         "storage": {
                             "type": "object",
                             "additionalProperties": false,
@@ -257,7 +275,7 @@
                 "null"
             ],
             "description": "Global values shared between all subcharts",
-            "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as the `additionalProperties` setting would otherwise collide with Helm's special 'global' values key."
+            "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as this schema would otherwise not allow Helm's special 'global' values key."
         },
         "image": {
             "type": "object",

--- a/helm/mcp-prometheus/values.yaml
+++ b/helm/mcp-prometheus/values.yaml
@@ -147,17 +147,43 @@ app:
 
   # OAuth 2.1 configuration (requires --enable-oauth flag and sse/streamable-http transport)
   oauth:
-    # Enable OAuth 2.1 authentication via Dex OIDC
+    # Enable OAuth 2.1 authentication via the platform identity provider.
     enabled: false
 
+    # Identity provider: dex | google. Rendered as MCP_OAUTH_PROVIDER.
+    #   dex    — Dex OIDC. Set DEX_ISSUER_URL and DEX_CLIENT_ID via app.env,
+    #            the client secret via dexClientSecret (or existingSecret).
+    #   google — Google OAuth. Set google.clientID and googleClientSecret
+    #            (or existingSecret). Google issues no groups claim, so pair it
+    #            with app.tenancy.mode "none" (or "static" with a tenant list).
+    provider: dex
+
+    # Public callback URL of this server, e.g.
+    # https://mcp-prometheus.example.com/oauth/callback. Rendered as
+    # OAUTH_REDIRECT_URL when set. Leave empty to keep providing
+    # DEX_REDIRECT_URL via app.env (legacy name, still honoured).
+    redirectURL: ""
+
+    # Google OAuth client (provider: google). The client ID is not secret and is
+    # rendered as the GOOGLE_CLIENT_ID env var.
+    google:
+      clientID: ""
+
     # Reference an existing Secret instead of creating one.
-    # When set, app.oauth.dexClientSecret and app.oauth.encryptionKey are ignored.
-    # The Secret must contain the keys: DEX_CLIENT_SECRET, MCP_OAUTH_ENCRYPTION_KEY
-    # and optionally VALKEY_PASSWORD.
+    # When set, app.oauth.dexClientSecret, app.oauth.googleClientSecret and
+    # app.oauth.encryptionKey are ignored. The Secret must contain the keys:
+    #   DEX_CLIENT_SECRET     (provider dex)    or
+    #   GOOGLE_CLIENT_SECRET  (provider google),
+    #   MCP_OAUTH_ENCRYPTION_KEY, and optionally VALKEY_PASSWORD.
     existingSecret: ""
 
-    # Dex OAuth client secret (stored in a K8s Secret)
+    # Dex OAuth client secret (provider: dex; stored in a chart-created Secret
+    # under the key DEX_CLIENT_SECRET)
     dexClientSecret: ""
+
+    # Google OAuth client secret (provider: google; stored in a chart-created
+    # Secret under the key GOOGLE_CLIENT_SECRET)
+    googleClientSecret: ""
 
     # AES-256-GCM encryption key for token storage (hex-encoded 32 bytes).
     # Generate with: openssl rand -hex 32
@@ -202,7 +228,7 @@ app:
     # How it works:
     #   - When a trusted audience is detected, the token is validated via JWT/JWKS
     #   - The IdP's JWKS endpoint is fetched to verify the token signature
-    #   - Tokens MUST still be from the configured issuer (Dex)
+    #   - Tokens MUST still be from the configured provider's issuer (Dex or Google)
     #   - Only explicitly listed client IDs are trusted
     #
     # Example: ["muster-client", "my-aggregator-client"]
@@ -214,6 +240,9 @@ app:
     # Resolution mode.
     #   grafana-organization — read GrafanaOrganization CRDs from Kubernetes (default).
     #   static               — fixed tenant list or group→tenants map from config.
+    #   none                 — single-tenant Prometheus: OAuth authenticates the
+    #                          caller, no tenant header is injected (an explicit
+    #                          org_id or PROMETHEUS_ORGID passes through verbatim).
     mode: "grafana-organization"
 
     static:
@@ -269,10 +298,12 @@ app:
     #   value: "https://mcp-prometheus.example.com"
     # - name: OAUTH_STORAGE
     #   value: "memory"
+    # Provider dex (app.oauth.provider: dex):
     # - name: DEX_ISSUER_URL
     #   value: "https://dex.example.com"
     # - name: DEX_CLIENT_ID
     #   value: "mcp-prometheus"
+    # Callback URL: prefer app.oauth.redirectURL; the legacy env var still works:
     # - name: DEX_REDIRECT_URL
     #   value: "https://mcp-prometheus.example.com/oauth/callback"
 

--- a/internal/oauth/setup.go
+++ b/internal/oauth/setup.go
@@ -16,6 +16,7 @@ import (
 	"github.com/giantswarm/mcp-oauth/handler"
 	"github.com/giantswarm/mcp-oauth/providers"
 	"github.com/giantswarm/mcp-oauth/providers/dex"
+	"github.com/giantswarm/mcp-oauth/providers/google"
 	mcpoidc "github.com/giantswarm/mcp-oauth/providers/oidc"
 	"github.com/giantswarm/mcp-oauth/security"
 	"github.com/giantswarm/mcp-oauth/storage"
@@ -55,6 +56,23 @@ type Config struct {
 	// ValkeyKeyPrefix is an optional key namespace prefix (default: "mcp:").
 	ValkeyKeyPrefix string
 
+	// Provider selects the upstream identity provider: [ProviderDex] (default)
+	// or [ProviderGoogle]. Read from MCP_OAUTH_PROVIDER.
+	Provider string
+
+	// RedirectURL is the callback URL registered at the identity provider,
+	// e.g. "https://mcp.example.com/oauth/callback". Read from
+	// OAUTH_REDIRECT_URL, falling back to the legacy DEX_REDIRECT_URL.
+	RedirectURL string
+
+	// GoogleClientID is the OAuth client ID of the Google Cloud OAuth client
+	// (provider "google").
+	GoogleClientID string
+
+	// GoogleClientSecret is the OAuth client secret of the Google Cloud OAuth
+	// client (provider "google").
+	GoogleClientSecret string
+
 	// DexIssuerURL is the Dex OIDC issuer, e.g. "https://dex.example.com".
 	DexIssuerURL string
 
@@ -64,14 +82,11 @@ type Config struct {
 	// DexClientSecret is the OAuth client secret registered in Dex.
 	DexClientSecret string
 
-	// DexRedirectURL is the callback URL registered in Dex,
-	// e.g. "https://mcp.example.com/oauth/callback".
-	DexRedirectURL string
-
 	// TrustedAudiences lists OAuth client IDs whose tokens are accepted for SSO.
 	// When an upstream aggregator (like muster) forwards a user's ID token,
 	// mcp-prometheus accepts it if the token's audience matches any entry here.
-	// Tokens must still be from the configured issuer (Dex) and cryptographically valid.
+	// Tokens must still be from the configured provider's issuer (Dex or
+	// Google) and cryptographically valid.
 	TrustedAudiences []string
 
 	// AllowPrivateURLs permits OIDC discovery against Dex instances whose hostname
@@ -82,6 +97,7 @@ type Config struct {
 	//
 	// Set MCP_OAUTH_ALLOW_PRIVATE_URLS=true only in trusted internal environments
 	// where the Dex issuer URL uses internal DNS. TLS verification is still enforced.
+	// Dex only; Google's endpoints are public.
 	AllowPrivateURLs bool
 
 	// DexCAFile is the path to a PEM-encoded CA certificate file used to verify
@@ -90,9 +106,26 @@ type Config struct {
 	// clusters). The pool is passed explicitly to the Dex provider client, the
 	// forwarded-ID-token JWKS validation, and trusted-issuer JWKS clients —
 	// mcp-oauth does not read a CA installed on http.DefaultTransport.
-	// Empty means the system trust store alone is used.
+	// Empty means the system trust store alone is used. Dex only.
 	DexCAFile string
 }
+
+// Supported values for [Config.Provider] / MCP_OAUTH_PROVIDER.
+const (
+	// ProviderDex uses a Dex OIDC issuer (DEX_ISSUER_URL, DEX_CLIENT_ID,
+	// DEX_CLIENT_SECRET). Default.
+	ProviderDex = "dex"
+
+	// ProviderGoogle uses Google as the OAuth 2.0 / OIDC provider
+	// (GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET).
+	ProviderGoogle = "google"
+)
+
+// googleScopes are requested from Google. Google ID tokens carry no groups
+// claim, so tenancy modes that need groups (grafana-organization, static
+// group map) cannot resolve tenants for Google users; use tenancy mode
+// "none" or a static all-users tenant list with this provider.
+var googleScopes = []string{"openid", "email", "profile"}
 
 // envTrue is the string value that enables a boolean env var.
 const envTrue = "true"
@@ -111,12 +144,23 @@ func ConfigFromEnv() Config {
 		ValkeyPassword:          os.Getenv("VALKEY_PASSWORD"),
 		ValkeyTLS:               os.Getenv("VALKEY_TLS_ENABLED") == envTrue,
 		ValkeyKeyPrefix:         os.Getenv("VALKEY_KEY_PREFIX"),
+		Provider:                strings.ToLower(strings.TrimSpace(os.Getenv("MCP_OAUTH_PROVIDER"))),
+		RedirectURL:             os.Getenv("OAUTH_REDIRECT_URL"),
+		GoogleClientID:          os.Getenv("GOOGLE_CLIENT_ID"),
+		GoogleClientSecret:      os.Getenv("GOOGLE_CLIENT_SECRET"),
 		DexIssuerURL:            os.Getenv("DEX_ISSUER_URL"),
 		DexClientID:             os.Getenv("DEX_CLIENT_ID"),
 		DexClientSecret:         os.Getenv("DEX_CLIENT_SECRET"),
-		DexRedirectURL:          os.Getenv("DEX_REDIRECT_URL"),
 		AllowPrivateURLs:        os.Getenv("MCP_OAUTH_ALLOW_PRIVATE_URLS") == envTrue,
 		DexCAFile:               os.Getenv("DEX_CA_FILE"),
+	}
+	if cfg.Provider == "" {
+		cfg.Provider = ProviderDex
+	}
+	if cfg.RedirectURL == "" {
+		// Legacy name from the Dex-only days; still honoured so existing
+		// deployments keep working.
+		cfg.RedirectURL = os.Getenv("DEX_REDIRECT_URL")
 	}
 	if v := os.Getenv("OAUTH_TRUSTED_AUDIENCES"); v != "" {
 		for a := range strings.SplitSeq(v, ",") {
@@ -135,18 +179,44 @@ func NewHandler(ctx context.Context, cfg Config, logger *slog.Logger) (*handler.
 	if cfg.Issuer == "" {
 		return nil, nil, fmt.Errorf("oauth: MCP_OAUTH_ISSUER must be set")
 	}
-	if cfg.DexIssuerURL == "" || cfg.DexClientID == "" || cfg.DexClientSecret == "" {
-		return nil, nil, fmt.Errorf("oauth: DEX_ISSUER_URL, DEX_CLIENT_ID, DEX_CLIENT_SECRET must all be set")
+	if cfg.RedirectURL == "" {
+		return nil, nil, fmt.Errorf("oauth: OAUTH_REDIRECT_URL (or legacy DEX_REDIRECT_URL) must be set")
 	}
-	if cfg.DexRedirectURL == "" {
-		return nil, nil, fmt.Errorf("oauth: DEX_REDIRECT_URL must be set")
+
+	var (
+		provider providers.Provider
+		rootCAs  *x509.CertPool
+		err      error
+	)
+	switch cfg.Provider {
+	case "", ProviderDex:
+		provider, rootCAs, err = newDexProvider(cfg, logger)
+	case ProviderGoogle:
+		provider, err = newGoogleProvider(cfg, logger)
+	default:
+		return nil, nil, fmt.Errorf("oauth: unsupported MCP_OAUTH_PROVIDER %q (supported: %s, %s)",
+			cfg.Provider, ProviderDex, ProviderGoogle)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return newHandlerWithProvider(ctx, provider, cfg, rootCAs, logger)
+}
+
+// newDexProvider validates the DEX_* configuration and builds the Dex OIDC
+// provider. It also returns the CA pool loaded from DEX_CA_FILE (nil = system
+// trust store) so the caller can hand it to the JWKS validation path.
+func newDexProvider(cfg Config, logger *slog.Logger) (providers.Provider, *x509.CertPool, error) {
+	if cfg.DexIssuerURL == "" || cfg.DexClientID == "" || cfg.DexClientSecret == "" {
+		return nil, nil, fmt.Errorf("oauth: DEX_ISSUER_URL, DEX_CLIENT_ID, DEX_CLIENT_SECRET must all be set for MCP_OAUTH_PROVIDER=%s", ProviderDex)
 	}
 
 	dexCfg := &dex.Config{
 		IssuerURL:    cfg.DexIssuerURL,
 		ClientID:     cfg.DexClientID,
 		ClientSecret: cfg.DexClientSecret,
-		RedirectURL:  cfg.DexRedirectURL,
+		RedirectURL:  cfg.RedirectURL,
 		// Request groups so the tenant resolver can match GrafanaOrganization RBAC.
 		Scopes: []string{"openid", "profile", "email", "groups", "offline_access"},
 	}
@@ -172,8 +242,36 @@ func NewHandler(ctx context.Context, cfg Config, logger *slog.Logger) (*handler.
 	if err != nil {
 		return nil, nil, fmt.Errorf("oauth: create Dex provider: %w", err)
 	}
+	logger.Info("Using Dex OIDC provider", "issuer", cfg.DexIssuerURL)
+	return provider, rootCAs, nil
+}
 
-	return newHandlerWithProvider(ctx, provider, cfg, rootCAs, logger)
+// newGoogleProvider validates the GOOGLE_* configuration and builds the Google
+// provider. Google's discovery, token and JWKS endpoints are public and served
+// with publicly trusted certificates, so DEX_CA_FILE and
+// MCP_OAUTH_ALLOW_PRIVATE_URLS do not apply and are ignored with a warning.
+func newGoogleProvider(cfg Config, logger *slog.Logger) (providers.Provider, error) {
+	if cfg.GoogleClientID == "" || cfg.GoogleClientSecret == "" {
+		return nil, fmt.Errorf("oauth: GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be set for MCP_OAUTH_PROVIDER=%s", ProviderGoogle)
+	}
+	if cfg.DexCAFile != "" {
+		logger.Warn("DEX_CA_FILE is ignored for the Google provider (Google endpoints use public CAs)", "caFile", cfg.DexCAFile)
+	}
+	if cfg.AllowPrivateURLs {
+		logger.Warn("MCP_OAUTH_ALLOW_PRIVATE_URLS is ignored for the Google provider (Google endpoints are public)")
+	}
+
+	provider, err := google.NewProvider(&google.Config{
+		ClientID:     cfg.GoogleClientID,
+		ClientSecret: cfg.GoogleClientSecret,
+		RedirectURL:  cfg.RedirectURL,
+		Scopes:       googleScopes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("oauth: create Google provider: %w", err)
+	}
+	logger.Info("Using Google OAuth provider")
+	return provider, nil
 }
 
 // loadRootCAs builds a certificate pool from the system pool plus the

--- a/internal/oauth/setup_test.go
+++ b/internal/oauth/setup_test.go
@@ -9,15 +9,18 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/giantswarm/mcp-oauth/providers/mock"
 )
 
 const (
-	testSecret    = "secret"
-	testDexIssuer = "https://dex.example.com"
-	testMCPIssuer = "https://mcp.example.com"
+	testSecret         = "secret"
+	testDexIssuer      = "https://dex.example.com"
+	testMCPIssuer      = "https://mcp.example.com"
+	testRedirectURL    = "https://mcp.example.com/oauth/callback"
+	testGoogleClientID = "1234.apps.googleusercontent.com"
 )
 
 func TestConfigFromEnvDefaults(t *testing.T) {
@@ -31,12 +34,19 @@ func TestConfigFromEnvDefaults(t *testing.T) {
 		"OAUTH_STORAGE", "VALKEY_URL", "VALKEY_PASSWORD",
 		"VALKEY_TLS_ENABLED", "VALKEY_KEY_PREFIX",
 		"DEX_ISSUER_URL", "DEX_CLIENT_ID", "DEX_CLIENT_SECRET", "DEX_REDIRECT_URL",
+		"MCP_OAUTH_PROVIDER", "OAUTH_REDIRECT_URL", "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET",
 	} {
 		t.Setenv(key, "")
 	}
 
 	cfg := ConfigFromEnv()
 
+	if cfg.Provider != ProviderDex {
+		t.Errorf("expected Provider %q by default, got %q", ProviderDex, cfg.Provider)
+	}
+	if cfg.RedirectURL != "" {
+		t.Errorf("expected empty RedirectURL by default, got %q", cfg.RedirectURL)
+	}
 	if cfg.StorageType != "" {
 		t.Errorf("expected empty StorageType by default, got %q", cfg.StorageType)
 	}
@@ -64,6 +74,8 @@ func TestConfigFromEnvReadsValues(t *testing.T) {
 	t.Setenv("DEX_CLIENT_ID", "mcp-prometheus")
 	t.Setenv("DEX_CLIENT_SECRET", "dexsecret")
 	t.Setenv("DEX_REDIRECT_URL", "https://app.example.com/oauth/callback")
+	t.Setenv("OAUTH_REDIRECT_URL", "")
+	t.Setenv("MCP_OAUTH_PROVIDER", "")
 
 	cfg := ConfigFromEnv()
 
@@ -81,7 +93,9 @@ func TestConfigFromEnvReadsValues(t *testing.T) {
 		{"DexIssuerURL", cfg.DexIssuerURL, testDexIssuer},
 		{"DexClientID", cfg.DexClientID, "mcp-prometheus"},
 		{"DexClientSecret", cfg.DexClientSecret, "dexsecret"},
-		{"DexRedirectURL", cfg.DexRedirectURL, "https://app.example.com/oauth/callback"},
+		// Legacy DEX_REDIRECT_URL is honoured when OAUTH_REDIRECT_URL is unset.
+		{"RedirectURL", cfg.RedirectURL, "https://app.example.com/oauth/callback"},
+		{"Provider", cfg.Provider, ProviderDex},
 	}
 	for _, c := range checks {
 		if c.got != c.want {
@@ -105,14 +119,109 @@ func TestConfigFromEnvAllowPrivateURLs(t *testing.T) {
 	}
 }
 
+func TestConfigFromEnvGoogleProvider(t *testing.T) {
+	t.Setenv("MCP_OAUTH_PROVIDER", " Google ") // normalised: trimmed + lower-cased
+	t.Setenv("GOOGLE_CLIENT_ID", testGoogleClientID)
+	t.Setenv("GOOGLE_CLIENT_SECRET", testSecret)
+	t.Setenv("OAUTH_REDIRECT_URL", testRedirectURL)
+	t.Setenv("DEX_REDIRECT_URL", "https://legacy.example.com/oauth/callback")
+
+	cfg := ConfigFromEnv()
+
+	if cfg.Provider != ProviderGoogle {
+		t.Errorf("Provider: got %q, want %q", cfg.Provider, ProviderGoogle)
+	}
+	if cfg.GoogleClientID != testGoogleClientID {
+		t.Errorf("GoogleClientID: got %q", cfg.GoogleClientID)
+	}
+	if cfg.GoogleClientSecret != testSecret {
+		t.Errorf("GoogleClientSecret: got %q", cfg.GoogleClientSecret)
+	}
+	// OAUTH_REDIRECT_URL takes precedence over the legacy DEX_REDIRECT_URL.
+	if cfg.RedirectURL != testRedirectURL {
+		t.Errorf("RedirectURL: got %q, want %q", cfg.RedirectURL, testRedirectURL)
+	}
+}
+
 // --- NewHandler validation errors (no Dex/network required) ---
+
+func TestNewHandlerUnknownProvider(t *testing.T) {
+	cfg := Config{
+		Issuer:      testMCPIssuer,
+		RedirectURL: testRedirectURL,
+		Provider:    "okta",
+	}
+	_, _, err := NewHandler(context.Background(), cfg, slog.Default())
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+	if !strings.Contains(err.Error(), "unsupported MCP_OAUTH_PROVIDER") {
+		t.Errorf("error should name the env var, got: %v", err)
+	}
+}
+
+func TestNewHandlerGoogleMissingClientID(t *testing.T) {
+	cfg := Config{
+		Issuer:             testMCPIssuer,
+		RedirectURL:        testRedirectURL,
+		Provider:           ProviderGoogle,
+		GoogleClientSecret: testSecret,
+	}
+	_, _, err := NewHandler(context.Background(), cfg, slog.Default())
+	if err == nil {
+		t.Fatal("expected error when GOOGLE_CLIENT_ID is empty")
+	}
+	if !strings.Contains(err.Error(), "GOOGLE_CLIENT_ID") {
+		t.Errorf("error should name GOOGLE_CLIENT_ID, got: %v", err)
+	}
+}
+
+func TestNewHandlerGoogleMissingClientSecret(t *testing.T) {
+	cfg := Config{
+		Issuer:         testMCPIssuer,
+		RedirectURL:    testRedirectURL,
+		Provider:       ProviderGoogle,
+		GoogleClientID: testGoogleClientID,
+	}
+	_, _, err := NewHandler(context.Background(), cfg, slog.Default())
+	if err == nil {
+		t.Fatal("expected error when GOOGLE_CLIENT_SECRET is empty")
+	}
+	if !strings.Contains(err.Error(), "GOOGLE_CLIENT_SECRET") {
+		t.Errorf("error should name GOOGLE_CLIENT_SECRET, got: %v", err)
+	}
+}
+
+// TestNewHandlerGoogleProvider proves the Google path needs none of the DEX_*
+// variables. Google's endpoints are static, so no network access is required
+// to construct the provider or the server.
+func TestNewHandlerGoogleProvider(t *testing.T) {
+	cfg := Config{
+		Issuer:             testMCPIssuer,
+		RedirectURL:        testRedirectURL,
+		Provider:           ProviderGoogle,
+		GoogleClientID:     testGoogleClientID,
+		GoogleClientSecret: testSecret,
+		// DEX_CA_FILE / private URLs are dex-only: they must be ignored, not fatal.
+		DexCAFile:        filepath.Join(t.TempDir(), "absent.crt"),
+		AllowPrivateURLs: true,
+	}
+	h, cleanup, err := NewHandler(context.Background(), cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cleanup()
+	if h == nil {
+		t.Error("expected non-nil handler")
+	}
+}
 
 func TestNewHandlerMissingIssuer(t *testing.T) {
 	cfg := Config{
 		DexIssuerURL:    testDexIssuer,
 		DexClientID:     "id",
 		DexClientSecret: testSecret,
-		DexRedirectURL:  "https://app.example.com/callback",
+		RedirectURL:     "https://app.example.com/callback",
 	}
 	_, _, err := NewHandler(context.Background(), cfg, slog.Default())
 	if err == nil {
@@ -125,7 +234,7 @@ func TestNewHandlerMissingDexIssuer(t *testing.T) {
 		Issuer:          testMCPIssuer,
 		DexClientID:     "id",
 		DexClientSecret: testSecret,
-		DexRedirectURL:  "https://app.example.com/callback",
+		RedirectURL:     "https://app.example.com/callback",
 	}
 	_, _, err := NewHandler(context.Background(), cfg, slog.Default())
 	if err == nil {
@@ -139,11 +248,11 @@ func TestNewHandlerMissingRedirectURL(t *testing.T) {
 		DexIssuerURL:    testDexIssuer,
 		DexClientID:     "id",
 		DexClientSecret: testSecret,
-		// DexRedirectURL intentionally missing
+		// RedirectURL intentionally missing
 	}
 	_, _, err := NewHandler(context.Background(), cfg, slog.Default())
 	if err == nil {
-		t.Error("expected error when DexRedirectURL is empty")
+		t.Error("expected error when RedirectURL is empty")
 	}
 }
 
@@ -307,7 +416,7 @@ func TestNewHandlerUnreadableDexCAFile(t *testing.T) {
 		DexIssuerURL:    testDexIssuer,
 		DexClientID:     "mcp-prometheus",
 		DexClientSecret: testSecret,
-		DexRedirectURL:  testMCPIssuer + "/oauth/callback",
+		RedirectURL:     testMCPIssuer + "/oauth/callback",
 		DexCAFile:       filepath.Join(t.TempDir(), "absent.crt"),
 	}
 	if _, _, err := NewHandler(t.Context(), cfg, slog.Default()); err == nil {

--- a/internal/server/context.go
+++ b/internal/server/context.go
@@ -73,7 +73,9 @@ func WithOAuthEnabled(enabled bool) ServerOption {
 }
 
 // WithTenancyResolver attaches a tenancy resolver used by tools to map
-// authenticated user groups to Mimir X-Scope-OrgID values.
+// authenticated user groups to Mimir X-Scope-OrgID values. A nil resolver is
+// valid (tenancy mode "none"): tools then pass explicit org IDs through
+// verbatim and inject no tenant header.
 func WithTenancyResolver(r TenancyResolver) ServerOption {
 	return func(sc *ServerContext) {
 		sc.tenancyResolver = r

--- a/internal/server/context_test.go
+++ b/internal/server/context_test.go
@@ -48,6 +48,23 @@ func TestWithTenancyResolver(t *testing.T) {
 	}
 }
 
+func TestWithTenancyResolverNil(t *testing.T) {
+	// Tenancy mode "none" hands a nil resolver to the option; OAuth stays on.
+	sc, err := NewServerContext(context.Background(),
+		WithOAuthEnabled(true),
+		WithTenancyResolver(nil),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sc.IsOAuthEnabled() {
+		t.Error("expected IsOAuthEnabled() == true")
+	}
+	if sc.TenancyResolver() != nil {
+		t.Errorf("expected TenancyResolver() == nil, got %v", sc.TenancyResolver())
+	}
+}
+
 func TestTenancyResolverNilByDefault(t *testing.T) {
 	sc, err := NewServerContext(context.Background())
 	if err != nil {

--- a/internal/tenancy/mode.go
+++ b/internal/tenancy/mode.go
@@ -23,6 +23,13 @@ const (
 	//   - Group-mapping: a map of group name → tenant IDs is used to collect tenants
 	//     for the user's JWT groups, with results deduplicated and sorted.
 	ModeStatic Mode = "static"
+
+	// ModeNone performs no tenant resolution. OAuth still authenticates the
+	// caller, but no tenant is derived from the identity and no X-Scope-OrgID
+	// header is injected; an explicit org_id (tool parameter or
+	// PROMETHEUS_ORGID) is passed through verbatim. Use this for a
+	// single-tenant Prometheus that has no Mimir tenants.
+	ModeNone Mode = "none"
 )
 
 // NewResolverForMode constructs the [server.TenancyResolver] for the given mode.
@@ -33,6 +40,9 @@ const (
 // For [ModeStatic] a [StaticResolver] is returned. When groupMap is non-nil and
 // non-empty, it is used for group-based resolution and staticTenants is ignored.
 // Otherwise staticTenants is returned for every authenticated user.
+//
+// For [ModeNone] a nil resolver is returned without error; callers treat a nil
+// resolver as "no tenancy" and pass any explicit org_id through unchanged.
 //
 // The function name avoids a collision with the existing [NewResolver] constructor
 // that accepts a dynamic Kubernetes client.
@@ -46,7 +56,10 @@ func NewResolverForMode(mode Mode, staticTenants []string, groupMap map[string][
 				"set MCP_STATIC_TENANTS or MCP_STATIC_GROUPS, otherwise every authenticated request will be denied")
 		}
 		return NewStaticResolver(staticTenants, groupMap), nil
+	case ModeNone:
+		return nil, nil
 	default:
-		return nil, fmt.Errorf("tenancy: unknown mode %q (valid: grafana-organization, static)", mode)
+		return nil, fmt.Errorf("tenancy: unknown mode %q (valid: %s, %s, %s)", mode,
+			ModeGrafanaOrganization, ModeStatic, ModeNone)
 	}
 }

--- a/internal/tenancy/mode_test.go
+++ b/internal/tenancy/mode_test.go
@@ -31,6 +31,22 @@ func TestNewResolverForMode_GrafanaOrganization_ErrorOutsideCluster(t *testing.T
 	}
 }
 
+func TestNewResolverForMode_None(t *testing.T) {
+	// "none" must yield a nil resolver (untyped nil interface) and no error so
+	// tool handlers pass explicit org IDs through without touching the identity.
+	r, err := NewResolverForMode(ModeNone, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r != nil {
+		t.Errorf("expected nil resolver for mode none, got %T", r)
+	}
+	// Static configuration is irrelevant in none mode and must not be rejected.
+	if _, err := NewResolverForMode(ModeNone, []string{tenantProdEU}, map[string][]string{groupTeamOps: {tenantProdEU}}); err != nil {
+		t.Errorf("unexpected error with ignored static config: %v", err)
+	}
+}
+
 func TestNewResolverForMode_UnknownMode(t *testing.T) {
 	_, err := NewResolverForMode(Mode("invalid-mode"), nil, nil)
 	if err == nil {

--- a/internal/tools/prometheus/tools_test.go
+++ b/internal/tools/prometheus/tools_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/giantswarm/mcp-oauth/handler"
+	"github.com/giantswarm/mcp-oauth/providers"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
@@ -912,5 +914,93 @@ func TestGetRulesSendsNoMatchers(t *testing.T) {
 	}
 	if len(gotMatchers) != 0 {
 		t.Errorf("expected no match[] query params, got %q", gotMatchers)
+	}
+}
+
+// --- resolveTenantOrgID ---
+
+const testTenant = "team-a"
+
+// stubTenancyResolver returns a fixed tenant list for every group set.
+type stubTenancyResolver struct{ tenants []string }
+
+func (s *stubTenancyResolver) TenantsForGroups(_ context.Context, _ []string) ([]string, error) {
+	return s.tenants, nil
+}
+
+func newTenancyTestContext(t *testing.T, opts ...server.ServerOption) *server.ServerContext {
+	t.Helper()
+	opts = append([]server.ServerOption{server.WithSlogLogger(discardLogger())}, opts...)
+	sc, err := server.NewServerContext(context.Background(), opts...)
+	if err != nil {
+		t.Fatalf("Failed to create server context: %v", err)
+	}
+	t.Cleanup(func() { _ = sc.Shutdown() })
+	return sc
+}
+
+func TestResolveTenantOrgID_OAuthDisabled(t *testing.T) {
+	sc := newTenancyTestContext(t)
+	for _, explicit := range []string{"", testTenant} {
+		got, err := resolveTenantOrgID(context.Background(), sc, explicit)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != explicit {
+			t.Errorf("explicit %q: got %q, want passthrough", explicit, got)
+		}
+	}
+}
+
+// TestResolveTenantOrgID_NilResolver covers tenancy mode "none": OAuth is on
+// but no resolver is configured, so the explicit org_id is returned verbatim
+// (including the empty string) and no user info is required in ctx.
+func TestResolveTenantOrgID_NilResolver(t *testing.T) {
+	sc := newTenancyTestContext(t,
+		server.WithOAuthEnabled(true),
+		server.WithTenancyResolver(nil),
+	)
+	for _, explicit := range []string{"", testTenant} {
+		got, err := resolveTenantOrgID(context.Background(), sc, explicit)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != explicit {
+			t.Errorf("explicit %q: got %q, want passthrough", explicit, got)
+		}
+	}
+}
+
+func TestResolveTenantOrgID_ResolverRequiresUserInfo(t *testing.T) {
+	sc := newTenancyTestContext(t,
+		server.WithOAuthEnabled(true),
+		server.WithTenancyResolver(&stubTenancyResolver{tenants: []string{testTenant}}),
+	)
+	if _, err := resolveTenantOrgID(context.Background(), sc, ""); err == nil {
+		t.Fatal("expected error when no user info is in the context")
+	}
+}
+
+func TestResolveTenantOrgID_ResolverInjectsTenant(t *testing.T) {
+	sc := newTenancyTestContext(t,
+		server.WithOAuthEnabled(true),
+		server.WithTenancyResolver(&stubTenancyResolver{tenants: []string{testTenant}}),
+	)
+	ctx := handler.ContextWithUserInfo(context.Background(), &providers.UserInfo{
+		ID:     "user-1",
+		Groups: []string{"team-a-admins"},
+	})
+
+	got, err := resolveTenantOrgID(ctx, sc, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != testTenant {
+		t.Errorf("got %q, want %q", got, testTenant)
+	}
+
+	// An explicit org_id outside the allowed set is rejected.
+	if _, err := resolveTenantOrgID(ctx, sc, "other-tenant"); err == nil {
+		t.Error("expected error for org_id outside the allowed tenants")
 	}
 }


### PR DESCRIPTION
## Why

muster forwards the platform IdP's `id_token` byte-identical to downstream MCP servers (`auth.forwardToken: true`), and every Agent Platform MCP server must be an mcp-oauth resource server that validates that token and acts with the user's identity. Two gaps blocked that for mcp-prometheus outside the Dex + Mimir fleet shape:

- **The platform IdP on spidertron is Google**, but `internal/oauth` only knew how to build the Dex provider (`DEX_*` were unconditionally required).
- **A single-tenant Prometheus has no Mimir tenants.** `SelectOrgID` denies users with zero tenants, so with OAuth on and no GrafanaOrganization / static tenant list, every tool call was rejected. There is no `X-Scope-OrgID` to inject on a plain Prometheus.

## What changed

### Go

- `MCP_OAUTH_PROVIDER` selects the identity provider: `dex` (default, unchanged behaviour) or `google` (`github.com/giantswarm/mcp-oauth/providers/google`). The Google provider implements `providers.JWKSProvider`, so the forwarded-token SSO path (`OAUTH_TRUSTED_AUDIENCES`) works unchanged against Google's JWKS.
- Per-provider validation: the "`DEX_ISSUER_URL`, `DEX_CLIENT_ID`, `DEX_CLIENT_SECRET` must all be set" check now applies to `dex` only; `google` requires `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` (same names as mcp-kubernetes). Unknown providers are rejected with a clear error. `DEX_CA_FILE` / `MCP_OAUTH_ALLOW_PRIVATE_URLS` stay dex-only and are ignored with a warning for Google (public endpoints, `JWKSRootCAs` nil).
- Provider-neutral `OAUTH_REDIRECT_URL`, falling back to the legacy `DEX_REDIRECT_URL` so existing deployments keep working.
- Tenancy mode `none` (`--tenancy-mode none`): `NewResolverForMode` returns a nil resolver without error; `resolveTenantOrgID` already passes the explicit `org_id` through verbatim when the resolver is nil (now covered by tests). OAuth still authenticates the caller; no tenant header is injected. `WithTenancyResolver(nil)` is documented and tested as valid.
- `serve` help text and README updated (env var tables per provider, "None mode" section, Google + single-tenant Helm example).

### Helm chart (`helm/mcp-prometheus`)

| Value | Renders | Notes |
|---|---|---|
| `app.oauth.provider` (`dex`) | env `MCP_OAUTH_PROVIDER` | `dex` \| `google`; anything else fails at render time |
| `app.oauth.redirectURL` (`""`) | env `OAUTH_REDIRECT_URL` when set | leaving it empty keeps `DEX_REDIRECT_URL` via `app.env` working |
| `app.oauth.google.clientID` (`""`) | env `GOOGLE_CLIENT_ID` when set | not secret |
| `app.oauth.googleClientSecret` (`""`) | Secret key `GOOGLE_CLIENT_SECRET` | required when provider is `google` and no `existingSecret`; `dexClientSecret` → `DEX_CLIENT_SECRET` stays for `dex` |
| `app.oauth.existingSecret` | `envFrom` | documented contract: `DEX_CLIENT_SECRET` (dex) or `GOOGLE_CLIENT_SECRET` (google) + `MCP_OAUTH_ENCRYPTION_KEY` (+ optional `VALKEY_PASSWORD`) |
| `app.tenancy.mode: none` | `--tenancy-mode=none` | schema does not constrain the value; the ClusterRole/ClusterRoleBinding for GrafanaOrganizations is now only created for `grafana-organization` |

The CNP is unchanged: egress to `world` when OAuth is on (Google discovery/JWKS need it). `values.schema.json` and the chart README are regenerated by the pre-commit hooks.

## Configuring the spidertron shape

```yaml
app:
  oauth:
    enabled: true
    provider: google
    redirectURL: https://mcp-prometheus.<domain>/oauth/callback
    google:
      clientID: <this server's Google OAuth client id>
    existingSecret: mcp-prometheus-oauth   # keys: GOOGLE_CLIENT_SECRET, MCP_OAUTH_ENCRYPTION_KEY
    trustedAudiences:
      - <the platform Google client id muster logs users in with>
  tenancy:
    mode: none
  env:
    - name: MCP_OAUTH_ISSUER
      value: https://mcp-prometheus.<domain>
    - name: PROMETHEUS_URL
      value: http://prometheus-operated.monitoring:9090
```

Rendered env for that shape (`helm template`): `MCP_OAUTH_PROVIDER=google`, `OAUTH_REDIRECT_URL=…`, `GOOGLE_CLIENT_ID=…`, `MCP_OAUTH_ALLOW_PUBLIC_REGISTRATION=false`, `MCP_OAUTH_ALLOW_PRIVATE_URLS=false`, `OAUTH_TRUSTED_AUDIENCES=…`, plus `envFrom` the OAuth Secret; args carry `--enable-oauth --tenancy-mode=none`.

## Verification

- `go build ./... && go test ./...` green; new unit tests: `ConfigFromEnv` reads `MCP_OAUTH_PROVIDER` / `GOOGLE_*` / `OAUTH_REDIRECT_URL` (with `DEX_REDIRECT_URL` fallback and precedence), `NewHandler` errors for missing Google client id/secret and for unknown providers, a full `NewHandler` success on the Google path without any `DEX_*` set, `NewResolverForMode(ModeNone)` returns a nil resolver, `resolveTenantOrgID` passthrough with a nil resolver (and the resolver path with/without user info).
- `pre-commit run --all-files` clean on the second pass (schema + chart README regenerated by the hooks).
- `helm lint` clean; `helm template` with defaults, the Google + `none` shape, and the Dex shape (`dexCASecret`, `allowPrivateURLs`); render-time failures verified for a missing `googleClientSecret` and an unknown provider; no Secret rendered with `existingSecret`; no ClusterRole for `static` / `none`.
- **Lab-verified only via unit tests + `helm template`** so far. The agentlab / spidertron run happens after the release.
